### PR TITLE
Fixing bower install repository URL to work over http instead of ssh

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,6 +17,6 @@
     "KineticJS": "http://d3lp1msu2r81bx.cloudfront.net/kjs/js/lib/kinetic-v4.5.5.min.js",
     "eventEmitter": "~4.2.1",
     "handlebars": "~1.0.0",
-    "waveform-data": "git@github.com:bbcrd/waveform-data.js.git"
+    "waveform-data": "~1.1.1"
   }
 }


### PR DESCRIPTION
At the bower install step of the install, this is what I get.

```
bower ECMDERR       Failed to execute "git ls-remote --tags --heads git@github.com:bbcrd/waveform-data.js.git", exit code of #128

Additional error details:
Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```

Any ideas? I'm really excited to try this out, its exactly what I need for an idea I have.
