### PR TITLE
Changing the `audio.currentTime` has weird side effects

### DIFF
--- a/lib/js/waveform_viewer/player/waveform/waveform.zoomview.js
+++ b/lib/js/waveform_viewer/player/waveform/waveform.zoomview.js
@@ -302,7 +302,6 @@ define([
     }
 
     that.uiLayer.draw();
-    bootstrap.pubsub.emit("waveform_seek", that.data.time(pixelIndex));
   };
 
   WaveformZoomView.prototype.seekFrame = function (pixelIndex) {

--- a/test/unit/player-spec.js
+++ b/test/unit/player-spec.js
@@ -1,0 +1,88 @@
+define(['m/bootstrap', 'main', 'jquery', 'underscore', 'Kinetic'], function(bootstrap, originalPeaks, $, _, Kinetic){
+
+  describe("m/player/player", function () {
+
+    var Peaks, sandbox;
+
+    var fixtures = jasmine.getFixtures();
+    fixtures.fixturesPath = 'base/test/';
+    fixtures.preload('audioElement.html.js');
+
+    /**
+     * SETUP =========================================================
+     */
+
+    beforeEach(function(){
+      sandbox = sinon.sandbox.create();
+      var ready = false;
+
+      runs(function () {
+        fixtures.load('audioElement.html.js');
+        $("#audioElement")[0].src = 'base/test_data/sample.mp3';
+      });
+
+      waitsFor(function () {
+        return $("#audioElement")[0].readyState == 4;
+      }, "Audio Element should have loaded", 60000);
+
+      runs(function () {
+
+        Peaks = $.extend({}, originalPeaks);
+
+        Peaks.init({
+          container: document.getElementById('waveform-visualiser-container'),
+          audioElement: $('#audioElement')[0],
+          dataUri: 'base/test_data/sample.dat',
+          keyboard: true,
+          height: 240
+        });
+
+        setTimeout(function () { // Should be reworked so that Peaks emits a ready event
+          ready = true;
+        }, 2000);
+      });
+
+      waitsFor(function () {
+        return ready;
+      }, "Peaks should initialise", 4000);
+
+    });
+
+    /**
+     * TEARDOWN ======================================================
+     */
+
+    afterEach(function () {
+      Peaks = null;
+      $("#audioElement")[0].src = '';
+
+      sandbox.restore();
+    });
+
+    /**
+     * TESTS =========================================================
+     */
+
+    describe("player.currentTime", function(){
+      //@see https://github.com/bbcrd/peaks.js/issues/12
+      //for some reason, the event is not emitted during the tests
+      xit("should trigger any `waveform_seek` event when changing audio element `currentTime`", function(){
+        var emitterSpy = sandbox.spy(bootstrap.pubsub, 'emit');
+        var syncPlayheadSpy = sandbox.spy(peaks.waveform.waveformZoomView, 'syncPlayhead');
+
+        runs(function(){
+          peaks.player.player.currentTime = 6;
+        });
+
+        waitsFor(function(){
+          return syncPlayheadSpy.called;
+        }, 1000);
+
+        runs(function(){
+          expect(emitterSpy.calledWith('waveform_seek')).toBe(true);
+        });
+      });
+    });
+  });
+
+});


### PR DESCRIPTION
For some reasons, some timeframes move the cursor to a different position as the requested one.

``` js
var a = document.querySelector('audio')
a.currentTime = 6;

player_time_update at 6
player_time_update at 5.990748
player_time_update at 5.979138
player_time_update at 5.967528
player_time_update at 5.955918
player_time_update at 5.944308
player_time_update at 5.932698
player_time_update at 5.921088
player_time_update at 5.909478
player_time_update at 5.897868
player_time_update at 5.886259 
```
