### PR TITLE
Moving the playhead in views should update the audio element currentTime

### DIFF
--- a/lib/js/waveform_viewer/player/waveform/waveform.zoomview.js
+++ b/lib/js/waveform_viewer/player/waveform/waveform.zoomview.js
@@ -72,6 +72,7 @@ define([
           // Set playhead position
           that.currentTime = that.data.time(that.frameOffset + x);
           that.syncPlayhead(that.frameOffset + x);
+          options.audioElement.currentTime = that.currentTime;
 
           // enable drag if necessary
           that.stage.on("mousemove", function (event) {


### PR DESCRIPTION
Probably a bug introduced by removing the `waveform_seek` event in the `syncPlayhead` method.
