### PR TITLE
Skipping in audio via JS doesn't move zoomed-in view

### DIFF
--- a/test/unit/api-spec.js
+++ b/test/unit/api-spec.js
@@ -42,7 +42,7 @@ define(['main', 'jquery', 'underscore', 'Kinetic'], function(originalPeaks, $, _
     });
 
     //@see https://github.com/bbcrd/peaks.js/issues/9
-    xit("should return the correct time for time.getCurrentTime()", function (done) {
+    it("should return the correct time for time.getCurrentTime()", function (done) {
       //Peaks.player.player.currentTime = 6;
       document.querySelector('audio').currentTime = 6;
 

--- a/test/unit/player-spec.js
+++ b/test/unit/player-spec.js
@@ -31,9 +31,8 @@ define(['m/bootstrap', 'main', 'jquery', 'underscore', 'Kinetic'], function(boot
       //@see https://github.com/bbcrd/peaks.js/issues/9
       //@see https://github.com/bbcrd/peaks.js/issues/12
       //for some reason, the event is not emitted during the tests
-      xit("should trigger any `waveform_seek` event when changing audio element `currentTime`", function(done){
+      it("should trigger any `waveform_seek` event when changing audio element `currentTime`", function(done){
         var emitterSpy = sandbox.spy(bootstrap.pubsub, 'emit');
-        var syncPlayheadSpy = sandbox.spy(Peaks.waveform.waveformZoomView, 'syncPlayhead');
 
         Peaks.player.player.currentTime = 6;
 


### PR DESCRIPTION
If I have a peaks.js instance on a page and I run the following:

``` javascript
window.peaks.player.pause()
window.peaks.player.seekBySeconds(seconds)
window.peaks.player.play()
```

... where seconds is a valid timestamp in the file being played, then the player will seek ahead and continue to play, the zoomed-out part of the peaks.js viewer will move ahead, but the zoomed-in part stops animating until the player is manually paused (via browser controls). No errors are observed in the console. When the player is paused, the zoomed-in part will jump ahead to the new paused location of the playhead.

Tested in Firefox 26 and Chromium 32 on Windows and Linux, behavior is consistent across those.
