### PR TITLE
Zooming out is creating an Out of Range exception

### DIFF
--- a/lib/js/waveform_viewer/player/waveform/waveform.zoomview.js
+++ b/lib/js/waveform_viewer/player/waveform/waveform.zoomview.js
@@ -77,6 +77,8 @@ define([
             x = event.layerX;
             p = that.frameOffset+dX;
             p = p < 0 ? 0 : p > (that.pixelLength - that.width) ? (that.pixelLength - that.width) : p;
+
+            that.frameOffset = p;
             that.updateZoomWaveform(p);
           });
           $(document).on("mouseup", function () {
@@ -216,8 +218,6 @@ define([
   WaveformZoomView.prototype.updateZoomWaveform = function (pixelOffset) {
     var that = this;
 
-    that.frameOffset = pixelOffset;
-
     var display = (that.playheadPixel >= pixelOffset) && (that.playheadPixel <= pixelOffset + that.width);
 
     if (display) {
@@ -269,8 +269,7 @@ define([
 
       that.playheadPixel = that.frameOffset + positionInFrame;
 
-      if (positionInFrame > that.width) {
-        that.newFrame();
+      if (positionInFrame > that.width && that.newFrame(that.frameOffset)) {
         that.zoomPlayheadGroup.setAttr("x", 0);
         that.zoomPlayheadText.setText(mixins.niceTime(that.data.time(0), false));
         startPosition = 0;
@@ -285,10 +284,17 @@ define([
     that.playheadLineAnimation.start();
   };
 
-  WaveformZoomView.prototype.newFrame = function () {
-    var that = this;
-    that.frameOffset += that.width;
-    that.updateZoomWaveform(that.frameOffset);
+  WaveformZoomView.prototype.newFrame = function (frameOffset) {
+    var nextOffset = frameOffset + this.width;
+
+    if (nextOffset < this.data.adapter.length){
+      this.frameOffset = nextOffset;
+      this.updateZoomWaveform(nextOffset);
+
+      return true;
+    }
+
+    return false;
   };
 
   WaveformZoomView.prototype.syncPlayhead = function (pixelIndex) {


### PR DESCRIPTION
Sorry for being annoying with bugs but this one is low priority, still a bug though. :) Just thought to let you know anyway :)

If the playhead animation on the zoomview finishes first (before the playhead on the overview) it causes Range Error. Once this happens you cannot play it again without restarting the page. (See image attached.)

![ed138f0ebed5aedf3ba4290f0988bd95](https://f.cloud.github.com/assets/3653259/2124899/df4ec4a8-9247-11e3-9b8a-6df7f7a17186.png)
