### PR TITLE
Emitting a `segments.ready` event.

### DIFF
--- a/src/main/waveform/waveform.segments.js
+++ b/src/main/waveform/waveform.segments.js
@@ -178,6 +178,8 @@ define([
 
     this.init = function () {
       peaks.on("waveform_zoom_displaying", self.updateSegments);
+
+      peaks.emit("segments.ready");
     };
 
     /**


### PR DESCRIPTION
It enables to display segments whenever it is possible without messing with
race condition.
