### PR TITLE
adds web audio builder from waveform-data.js

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "KineticJS": "http://d3lp1msu2r81bx.cloudfront.net/kjs/js/lib/kinetic-v4.5.5.min.js",
     "eventEmitter": "~4.2.1",
-    "waveform-data": "https://github.com/chainlink/waveform-data.js.git#add-points"
+    "waveform-data": "~1.3.0"
   },
   "devDependencies": {
     "requirejs": "~2.1.11"

--- a/demo_page_dev.html
+++ b/demo_page_dev.html
@@ -26,7 +26,6 @@
           paths: {
             "peaks": "src/main",
             "waveform-data": "bower_components/waveform-data/dist/waveform-data.min",
-            "web-audio-builder": "bower_components/waveform-data/lib/builders/webaudio",
             "EventEmitter": "bower_components/eventEmitter/EventEmitter"
           }
         };
@@ -35,7 +34,7 @@
     <script src="bower_components/requirejs/require.js"></script>
 
     <script>
-        require(['web-audio-builder', 'peaks'], function (WebAudioBuilder, Peaks) {
+        require(['peaks'], function (Peaks) {
 
           var peaksInstance = Peaks.init({
             container: document.getElementById('first-waveform-visualiser-container'),
@@ -71,7 +70,7 @@
           Peaks.init({
             container: document.getElementById('second-waveform-visualiser-container'),
             mediaElement: document.getElementById('audio'),
-            dataUri: '/test_data/sample.mp3',
+            dataUri: '/test_data/sample.dat',
             keyboard: false,
             height: 120,
             zoomWaveformColor: '#AAAAAA',

--- a/src/main/waveform/waveform.core.js
+++ b/src/main/waveform/waveform.core.js
@@ -46,7 +46,7 @@ define([
             isAudioFile = true;
             xhr.responseType = 'arraybuffer';
             xhr.addEventListener("load", function onResponse(progressEvent) {
-                WaveformData.adapters.arraybuffer.fromAudioObject(progressEvent.target.response, function onProcessed(waveform) {
+                WaveformData.builders.webaudio(progressEvent.target.response, function onProcessed(waveform) {
 
                     console.log("Waveform Data Loaded!");
                     console.log("Duration: " + waveform.duration);


### PR DESCRIPTION
Adds web audio builder support (See: https://github.com/bbcrd/waveform-data.js/pull/18)

Note: Changed bower to link to my public fork of waveform-data. Will need to change back to BBC ref, when that is merged in.
