### PR TITLE
Added waveformZoomReady event (after segments and points initialized)

### DIFF
--- a/src/main/waveform/waveform.core.js
+++ b/src/main/waveform/waveform.core.js
@@ -115,13 +115,13 @@ define([
 
         that.waveformZoomView = new WaveformZoomView(that.origWaveformData, that.ui.zoom, peaks);
 
-        peaks.emit("waveform_zoom_start");
-
         that.segments = new WaveformSegments(peaks);
         that.segments.init();
 
         that.points = new WaveformPoints(peaks);
         that.points.init();
+
+        peaks.emit('waveformZoomReady');
       },
 
       /**


### PR DESCRIPTION
Needed event after peaks and points arrays initialized.

Removed unused event waveform_zoom_start
