### PR TITLE
Call bindResize before emitting waveformOverviewReady event

### DIFF
--- a/src/main/waveform/waveform.core.js
+++ b/src/main/waveform/waveform.core.js
@@ -63,8 +63,8 @@ define([
 
           that.waveformOverview = new WaveformOverview(overviewWaveformData, that.ui.overview, peaks);
 
-          peaks.emit("waveformOverviewReady");
           that.bindResize();
+          peaks.emit("waveformOverviewReady");
         };
       },
 


### PR DESCRIPTION
Otherwise that.bindResize(); never gets called.. and resize listener is never added to the window.
