### PR TITLE
EventEmitter2 prototype workaround.

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -202,8 +202,8 @@ define('peaks', [
     return instance;
   };
 
-
-  Peaks.prototype = Object.create(EventEmitter.prototype, {
+  // Temporary workaround while https://github.com/asyncly/EventEmitter2/pull/122
+  Peaks.prototype = Object.create((EventEmitter.EventEmitter2 || EventEmitter).prototype, {
     segments: {
       get: function () {
         var self = this;


### PR DESCRIPTION
fixes #77
refs asyncly/EventEmitter2#122
