### PR TITLE
Allow configuration of where segments are displayed

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -118,7 +118,13 @@ define('peaks', [
        */
       pointMarkerColor:     '#FF0000', //Color for the point marker
       pointDblClickHandler: null, //Handler called when point handle double clicked.
-      pointDragEndHandler:  null // Called when the point handle has finished dragging
+      pointDragEndHandler:  null, // Called when the point handle has finished dragging
+
+      /**
+       * Configure appearance, or non appearance, of segments
+       */
+      showSegmentsInZoomView : true, // whether segments are displayed in the Zoom view
+      showSegmentsInOverview: true // whether segments are displayed in the Overview view
 
     };
 


### PR DESCRIPTION
This commit adds initialization options to peaks, allowing you to specify whether segments should appear in the Zoom View, the Overview, or both.

Reference issue #89 

The default behaviour is for segments to appear in both views, so no existing code should be affected by this addition.

The following initialization object will tell peaks to only show segments in the Zoom View, and not in the Overview.

```
var options = {
  container: document.getElementById('first-waveform-visualiser-container'),
  mediaElement: document.querySelector('audio'),
  dataUri: {
    arraybuffer: '/test_data/sample.dat'
  },
  showSegmentsInZoomView: true,
  showSegmentsInOverview: false
};

var peaksInstance = Peaks.init(options);
```
