### PR TITLE
Adding 'refresh' function to peaks instance

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -133,6 +133,11 @@ define('peaks', [
      * @type {number}
      */
     this.currentZoomLevel = 0;
+
+	this.refresh = function(){
+		this.waveform.init(buildUi(this.container));
+	};
+
   }
 
   Peaks.init = function init (opts) {

--- a/src/main/waveform/waveform.core.js
+++ b/src/main/waveform/waveform.core.js
@@ -61,7 +61,7 @@ define([
         // WebAudio Builder
         if (!options.dataUri && WaveformData.builders.webaudio.getAudioContext()) {
           requestType = 'arraybuffer';
-          uri = options.mediaElement.currentSrc || options.mediaElement.src;
+          uri = options.mediaElement.src || options.mediaElement.currentSrc;
           builder = 'webaudio';
         }
 


### PR DESCRIPTION
Switched order of src and currentSrc.
(src is not set when setting audio via source tags in html. CurrentSrc
is not current when resetting src through javascript.)

See #69 
