### PR TITLE
Remove waveform-data as dependency in bower 

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,6 @@
     "test_data"
   ],
   "dependencies": {
-    "waveform-data": "~1.4.2",
     "requirejs": "~2.1.14",
     "eventemitter2": "~0.4.14",
     "kineticjs": "~5.1.0"


### PR DESCRIPTION
I think waveform-data can be removed from bower.json as it is already included in package.json. Both index.html and browserify pull from the node_modules version. It's a bit confusing to have it in both.
