### PR TITLE
Make point editable in zoom view only.

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
       }
 
       .overview-container {
-        height: 85px;
+        height: 100px;
       }
 
       #second-waveform-visualiser-container [class*="-container"] {

--- a/src/main/markers/waveform.points.js
+++ b/src/main/markers/waveform.points.js
@@ -6,8 +6,9 @@
  */
 define([
   "peaks/waveform/waveform.mixins",
-  "Kinetic"
-], function (mixins, Kinetic) {
+  "Kinetic",
+  "peaks/views/waveform.overview"
+], function (mixins, Kinetic, WaveformOverview) {
 
   return function (peaks) {
     var self = this;
@@ -35,11 +36,15 @@ define([
       pointGroups.forEach(function(pointGroup, i){
         var view = self.views[i];
 
-        if (point.editable) {
-          pointGroup.marker = new peaks.options.pointMarker(true, pointGroup, point, pointHandleDrag, peaks.options.pointDblClickHandler, peaks.options.pointDragEndHandler);
+        if(view instanceof WaveformOverview) {
+          pointGroup.marker = new peaks.options.pointMarker(false, pointGroup, point, null, null, null);
           pointGroup.add(pointGroup.marker);
+        } else {
+          if (point.editable) {
+            pointGroup.marker = new peaks.options.pointMarker(true, pointGroup, point, pointHandleDrag, peaks.options.pointDblClickHandler, peaks.options.pointDragEndHandler);
+            pointGroup.add(pointGroup.marker);
+          }
         }
-
         view.pointLayer.add(pointGroup);
       });
 
@@ -117,7 +122,7 @@ define([
         throw new RangeError("[waveform.points.createPoint] timestamp should be a >=0 value");
       }
 
-      point.id = "point" + self.points.length;
+        point.id = "point" + self.points.length;
 
       point = constructPoint(point);
       updatePoint(point);

--- a/src/main/markers/waveform.points.js
+++ b/src/main/markers/waveform.points.js
@@ -6,8 +6,7 @@
  */
 define([
   "peaks/waveform/waveform.mixins",
-  "Kinetic",
-  "peaks/views/waveform.overview"
+  "Kinetic"
 ], function (mixins, Kinetic, WaveformOverview) {
 
   return function (peaks) {
@@ -36,7 +35,7 @@ define([
       pointGroups.forEach(function(pointGroup, i){
         var view = self.views[i];
 
-        if(view instanceof WaveformOverview) {
+        if(view === peaks.waveform.waveformOverview) {
           pointGroup.marker = new peaks.options.pointMarker(false, pointGroup, point, null, null, null);
           pointGroup.add(pointGroup.marker);
         } else {

--- a/src/main/waveform/waveform.mixins.js
+++ b/src/main/waveform/waveform.mixins.js
@@ -171,17 +171,6 @@ define(['Kinetic'], function (Kinetic) {
           group.label = text;
 
           /*
-          Handle
-           */
-          var handle = new Kinetic.Rect({
-            width: handleWidth,
-            height: handleHeight,
-            fill: color,
-            x: handleX,
-            y: handleTop
-          });
-
-          /*
           Line
            */
           var line = new Kinetic.Line({
@@ -193,19 +182,32 @@ define(['Kinetic'], function (Kinetic) {
           });
 
           /*
-          Events
+          Handle
            */
-          handle.on("mouseover", function (event) {
-            text.show();
-            text.setX(xPosition - text.getWidth()); //Position text to the left of the mark
-            point.view.pointLayer.draw();
-          });
-          handle.on("mouseout", function (event) {
-            text.hide();
-            point.view.pointLayer.draw();
-          });
+          if(draggable) {
+            var handle = new Kinetic.Rect({
+              width: handleWidth,
+              height: handleHeight,
+              fill: color,
+              x: handleX,
+              y: handleTop
+            });
+          
 
-          group.add(handle);
+            /*
+            Events
+             */
+            handle.on("mouseover", function (event) {
+              text.show();
+              text.setX(xPosition - text.getWidth()); //Position text to the left of the mark
+              point.view.pointLayer.draw();
+            });
+            handle.on("mouseout", function (event) {
+              text.hide();
+              point.view.pointLayer.draw();
+            });
+            group.add(handle);
+          }
           group.add(line);
           group.add(text);
 
@@ -338,6 +340,10 @@ define(['Kinetic'], function (Kinetic) {
 
     defaultPointMarker: function (options) {
       return createPointHandle(options.height, options.pointMarkerColor);
+    },
+
+    defaultNonEditablePointMarker: function(options) {
+      return createNonEditablePointHandle(options.height, options.pointMarkerColor);
     },
 
     defaultSegmentLabelDraw: function (options) {

--- a/src/main/waveform/waveform.mixins.js
+++ b/src/main/waveform/waveform.mixins.js
@@ -342,10 +342,6 @@ define(['Kinetic'], function (Kinetic) {
       return createPointHandle(options.height, options.pointMarkerColor);
     },
 
-    defaultNonEditablePointMarker: function(options) {
-      return createNonEditablePointHandle(options.height, options.pointMarkerColor);
-    },
-
     defaultSegmentLabelDraw: function (options) {
       return function (segment, parent) {
         return new Kinetic.Text({


### PR DESCRIPTION
![screen shot 2014-09-28 at 12 04 50 pm](https://cloud.githubusercontent.com/assets/1187682/4461325/7bc085b0-48b9-11e4-8178-40954f18095c.png)

When the overview is sufficiently sized, the handle appears, but is not veritically centered to height. We think that it's also clutter to have the the drag handle in both places. This change makes points only editable in the zoom view.

Note: The demo commit can be omitted, as it only changes the height of the overview in the index.html
