### PR TITLE
Enable rendering of non-editable marker lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,10 @@ var options = {
   // Zoom view adapter to use. Valid adapters are: 'animated' (default) and 'static'
   zoomAdapter: 'animated',
 
+  // Show marker lines for uneditable segments and points on the following waveforms: 'overview', 'zoomview'.
+  // Default is none of them.
+  showMarkerLinesWhenUneditable: [],
+
   // Array of initial segment objects with startTime and
   // endTime in seconds and a boolean for editable.
   // See below.

--- a/src/main.js
+++ b/src/main.js
@@ -145,6 +145,12 @@ define('peaks', [
       pointDragEndHandler:  null, // Called when the point handle has finished dragging
 
       /**
+       * Show marker lines for uneditable segments and points on the following waveforms: 'overview', 'zoomview'.
+       * Default is none of them.
+       */
+      showMarkerLinesWhenUneditable: [],
+
+      /**
        * WaveformData WebAudio Decoder Options
        *
        * You mostly want to play with the 'scale' option.

--- a/src/main/markers/waveform.points.js
+++ b/src/main/markers/waveform.points.js
@@ -37,8 +37,10 @@ define([
 
         if (point.editable) {
           pointGroup.marker = new peaks.options.pointMarker(true, pointGroup, point, pointHandleDrag, peaks.options.pointDblClickHandler, peaks.options.pointDragEndHandler);
-          pointGroup.add(pointGroup.marker);
+        } else {
+          pointGroup.marker = new peaks.options.pointMarker(false, pointGroup, point);
         }
+        pointGroup.add(pointGroup.marker);
 
         view.pointLayer.add(pointGroup);
       });
@@ -59,9 +61,8 @@ define([
       // Overview
       var overviewtimestampOffset = waveformView.waveformOverview.data.at_time(point.timestamp);
 
-      if (point.editable) {
-        if (point.overview.marker) point.overview.marker.show().setX(overviewtimestampOffset - point.overview.marker.getWidth());
-
+      if (point.overview.marker) {
+        point.overview.marker.show().setX(overviewtimestampOffset - point.overview.marker.getWidth());
         // Change Text
         point.overview.marker.label.setText(mixins.niceTime(point.timestamp, false));
       }
@@ -79,9 +80,8 @@ define([
 
         point.zoom.show();
 
-        if (point.editable) {
-          if (point.zoom.marker) point.zoom.marker.show().setX(startPixel - point.zoom.marker.getWidth());
-
+        if (point.zoom.marker) {
+          point.zoom.marker.show().setX(startPixel - point.zoom.marker.getWidth());
           // Change Text
           point.zoom.marker.label.setText(mixins.niceTime(point.timestamp, false));
         }

--- a/src/main/markers/waveform.points.js
+++ b/src/main/markers/waveform.points.js
@@ -28,19 +28,22 @@ define([
     function constructPoint(point) {
       var pointZoomGroup = new Konva.Group();
       var pointOverviewGroup = new Konva.Group();
-      var pointGroups = [pointZoomGroup, pointOverviewGroup];
+      var pointGroups = [ { group: pointZoomGroup, view: 'zoomview' }, { group: pointOverviewGroup, view: 'overview' }];
 
       point.editable = Boolean(point.editable);
 
-      pointGroups.forEach(function(pointGroup, i){
+      pointGroups.forEach(function(item, i){
         var view = self.views[i];
+        var pointGroup = item.group;
 
         if (point.editable) {
           pointGroup.marker = new peaks.options.pointMarker(true, pointGroup, point, pointHandleDrag, peaks.options.pointDblClickHandler, peaks.options.pointDragEndHandler);
-        } else {
+          pointGroup.add(pointGroup.marker);
+
+        } else if (peaks.options.showMarkerLinesWhenUneditable.indexOf(item.view) > -1) {
           pointGroup.marker = new peaks.options.pointMarker(false, pointGroup, point);
+          pointGroup.add(pointGroup.marker);
         }
-        pointGroup.add(pointGroup.marker);
 
         view.pointLayer.add(pointGroup);
       });

--- a/src/main/markers/waveform.segments.js
+++ b/src/main/markers/waveform.segments.js
@@ -63,15 +63,12 @@ define([
         segmentGroup.label = new peaks.options.segmentLabelDraw(segmentGroup, segment);
         segmentGroup.add(segmentGroup.label.hide());
 
-        if (editable) {
-          var draggable = true;
+        var handleDrag = editable ? segmentHandleDrag : undefined;
+        segmentGroup.inMarker = new peaks.options.segmentInMarker(editable, segmentGroup, segment, handleDrag);
+        segmentGroup.outMarker = new peaks.options.segmentOutMarker(editable, segmentGroup, segment, handleDrag);
 
-          segmentGroup.inMarker = new peaks.options.segmentInMarker(draggable, segmentGroup, segment, segmentHandleDrag);
-          segmentGroup.add(segmentGroup.inMarker);
-
-          segmentGroup.outMarker = new peaks.options.segmentOutMarker(draggable, segmentGroup, segment, segmentHandleDrag);
-          segmentGroup.add(segmentGroup.outMarker);
-        }
+        segmentGroup.add(segmentGroup.inMarker);
+        segmentGroup.add(segmentGroup.outMarker);
 
         view.segmentLayer.add(segmentGroup);
       });
@@ -95,12 +92,15 @@ define([
 
       segment.overview.setWidth(overviewEndOffset - overviewStartOffset);
 
-      if (segment.editable) {
-        if (segment.overview.inMarker) segment.overview.inMarker.show().setX(overviewStartOffset - segment.overview.inMarker.getWidth());
-        if (segment.overview.outMarker) segment.overview.outMarker.show().setX(overviewEndOffset);
-
+      if (segment.overview.inMarker) {
+        segment.overview.inMarker.show().setX(overviewStartOffset - segment.overview.inMarker.getWidth());
         // Change Text
         segment.overview.inMarker.label.setText(mixins.niceTime(segment.startTime, false));
+      }
+
+      if (segment.overview.outMarker) {
+        segment.overview.outMarker.show().setX(overviewEndOffset);
+        // Change Text
         segment.overview.outMarker.label.setText(mixins.niceTime(segment.endTime, false));
       }
 
@@ -125,12 +125,15 @@ define([
 
         segment.zoom.show();
 
-        if (segment.editable) {
-          if (segment.zoom.inMarker) segment.zoom.inMarker.show().setX(startPixel - segment.zoom.inMarker.getWidth());
-          if (segment.zoom.outMarker) segment.zoom.outMarker.show().setX(endPixel);
-
+        if (segment.zoom.inMarker) {
+          segment.zoom.inMarker.show().setX(startPixel - segment.zoom.inMarker.getWidth());
           // Change Text
           segment.zoom.inMarker.label.setText(mixins.niceTime(segment.startTime, false));
+        }
+
+        if (segment.zoom.outMarker) {
+          segment.zoom.outMarker.show().setX(endPixel);
+          // Change Text
           segment.zoom.outMarker.label.setText(mixins.niceTime(segment.endTime, false));
         }
 

--- a/src/main/markers/waveform.segments.js
+++ b/src/main/markers/waveform.segments.js
@@ -38,7 +38,7 @@ define([
       var segmentZoomGroup = new Konva.Group();
       var segmentOverviewGroup = new Konva.Group();
 
-      var segmentGroups = [segmentZoomGroup, segmentOverviewGroup];
+      var segmentGroups = [{ group: segmentZoomGroup, view: 'zoomview' }, { group: segmentOverviewGroup, view: 'overview' }];
 
       var menter = function (event) {
         this.parent.label.show();
@@ -50,8 +50,9 @@ define([
         this.parent.view.segmentLayer.draw();
       };
 
-      segmentGroups.forEach(function(segmentGroup, i){
+      segmentGroups.forEach(function(item, i){
         var view = self.views[i];
+        var segmentGroup = item.group;
 
         segmentGroup.waveformShape = SegmentShape.createShape(segment, view);
 
@@ -63,12 +64,20 @@ define([
         segmentGroup.label = new peaks.options.segmentLabelDraw(segmentGroup, segment);
         segmentGroup.add(segmentGroup.label.hide());
 
-        var handleDrag = editable ? segmentHandleDrag : undefined;
-        segmentGroup.inMarker = new peaks.options.segmentInMarker(editable, segmentGroup, segment, handleDrag);
-        segmentGroup.outMarker = new peaks.options.segmentOutMarker(editable, segmentGroup, segment, handleDrag);
+        if (editable) {
+          segmentGroup.inMarker = new peaks.options.segmentInMarker(editable, segmentGroup, segment, segmentHandleDrag);
+          segmentGroup.outMarker = new peaks.options.segmentOutMarker(editable, segmentGroup, segment, segmentHandleDrag);
 
-        segmentGroup.add(segmentGroup.inMarker);
-        segmentGroup.add(segmentGroup.outMarker);
+          segmentGroup.add(segmentGroup.inMarker);
+          segmentGroup.add(segmentGroup.outMarker);
+
+        } else if (peaks.options.showMarkerLinesWhenUneditable.indexOf(item.view) > -1) {
+          segmentGroup.inMarker = new peaks.options.segmentInMarker(false, segmentGroup, segment);
+          segmentGroup.outMarker = new peaks.options.segmentOutMarker(false, segmentGroup, segment);
+
+          segmentGroup.add(segmentGroup.inMarker);
+          segmentGroup.add(segmentGroup.outMarker);
+        }
 
         view.segmentLayer.add(segmentGroup);
       });

--- a/src/main/waveform/waveform.mixins.js
+++ b/src/main/waveform/waveform.mixins.js
@@ -51,7 +51,9 @@ define(['konva'], function (Konva) {
           };
         }
       }).on("dragmove", function (event) {
-        onDrag(segment, parent);
+        if (typeof(onDrag) === 'function') {
+          onDrag(segment, parent);
+        }
       });
 
       var xPosition = inMarker ? -24 : 24;
@@ -92,19 +94,22 @@ define(['konva'], function (Konva) {
       /*
       Events
        */
-      handle.on("mouseover", function (event) {
-        if (inMarker) text.setX(xPosition - text.getWidth());
-        text.show();
-        segment.view.segmentLayer.draw();
-      });
-      handle.on("mouseout", function (event) {
-        text.hide();
-        segment.view.segmentLayer.draw();
-      });
+      if (draggable) {
+        handle.on("mouseover", function (event) {
+          if (inMarker) text.setX(xPosition - text.getWidth());
+          text.show();
+          segment.view.segmentLayer.draw();
+        });
+        handle.on("mouseout", function (event) {
+          text.hide();
+          segment.view.segmentLayer.draw();
+        });
+
+        group.add(handle);
+      }
 
       group.add(text);
       group.add(line);
-      group.add(handle);
 
       return group;
     };
@@ -122,7 +127,13 @@ define(['konva'], function (Konva) {
        * @param  {Object}   point     Parent point object with in times
        * @param  {Object}   parent    Parent context
        * @param  {Function} onDrag    Callback after drag completed
-       * @return {Konva Object}     Konva group object of handle marker elements
+       * @param  {Boolean}  draggable  If true, marker is draggable
+       * @param  {Object}   point      Parent point object with in times
+       * @param  {Object}   parent     Parent context
+       * @param  {Function} onDrag     Callback while dragging
+       * @param  {Function} onDblClick Callback on double click
+       * @param  {Function} onDragEnd  Callback after drag completed
+       * @return {Konva Object}        Konva group object of handle marker elements
        */
       return function (draggable, point, parent, onDrag, onDblClick, onDragEnd) {
           var handleTop = (height / 2) - 10.5;
@@ -140,18 +151,24 @@ define(['konva'], function (Konva) {
                   };
               }
           }).on("dragmove", function (event) {
-                  onDrag(point, parent);
+                  if (typeof(onDrag) === 'function') {
+                    onDrag(point, parent);
+                  }
               });
 
           if(onDblClick) {
               group.on('dblclick', function (event) {
-                  onDblClick(parent);
+                  if (typeof(onDblClick) === 'function') {
+                    onDblClick(parent);
+                  }
               });
           }
 
           if(onDragEnd) {
               group.on('dragend', function (event) {
-                  onDragEnd(parent);
+                  if (typeof(onDragEnd) === 'function') {
+                    onDragEnd(parent);
+                  }
               });
           }
 
@@ -195,17 +212,19 @@ define(['konva'], function (Konva) {
           /*
           Events
            */
-          handle.on("mouseover", function (event) {
-            text.show();
-            text.setX(xPosition - text.getWidth()); //Position text to the left of the mark
-            point.view.pointLayer.draw();
-          });
-          handle.on("mouseout", function (event) {
-            text.hide();
-            point.view.pointLayer.draw();
-          });
+          if (draggable) {
+            handle.on("mouseover", function (event) {
+              text.show();
+              text.setX(xPosition - text.getWidth()); //Position text to the left of the mark
+              point.view.pointLayer.draw();
+            });
+            handle.on("mouseout", function (event) {
+              text.hide();
+              point.view.pointLayer.draw();
+            });
 
-          group.add(handle);
+            group.add(handle);
+          }
           group.add(line);
           group.add(text);
 

--- a/src/main/waveform/waveform.mixins.js
+++ b/src/main/waveform/waveform.mixins.js
@@ -123,10 +123,6 @@ define(['konva'], function (Konva) {
    */
   function createPointHandle(height, color) {
       /**
-       * @param  {Boolean}  draggable If true, marker is draggable
-       * @param  {Object}   point     Parent point object with in times
-       * @param  {Object}   parent    Parent context
-       * @param  {Function} onDrag    Callback after drag completed
        * @param  {Boolean}  draggable  If true, marker is draggable
        * @param  {Object}   point      Parent point object with in times
        * @param  {Object}   parent     Parent context


### PR DESCRIPTION
Today, in Peaks, if a marker is not editable, only the waveform highlight gets rendered. If you want the lines on either side of the marker (or if it's a point, just the line) to be rendered, that cannot be controlled. This PR adds the ability to control if we draw marker lines or not (we do not draw the handle) if the marker is not editable.

This defaults to the existing behavior; users must opt-in and choose which waveforms they want the marker lines to render on if they want this feature.
