### PR TITLE
Fix mouse dragging behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,7 +470,6 @@ Peaks.js emits events to enable you to extend its behaviour according to your ne
 `zoomview_resized`         | N/A
 `user_seek.overview`       | `float time`
 `user_seek.zoomview`       | `float time`
-`user_scrub.overview`      | `float time`
 
 ### Waveforms
 

--- a/package.json
+++ b/package.json
@@ -24,8 +24,10 @@
     "peaks/waveform/waveform.axis": "./src/main/waveform/waveform.axis.js",
     "peaks/waveform/waveform.core": "./src/main/waveform/waveform.core.js",
     "peaks/waveform/waveform.mixins": "./src/main/waveform/waveform.mixins.js",
+    "peaks/waveform/waveform.utils": "./src/main/waveform/waveform.utils.js",
     "peaks/views/waveform.overview": "./src/main/views/waveform.overview.js",
     "peaks/views/waveform.zoomview": "./src/main/views/waveform.zoomview.js",
+    "peaks/views/helpers/mousedraghandler": "./src/main/views/helpers/mousedraghandler.js",
     "peaks/views/zooms/animated": "./src/main/views/zooms/animated.js",
     "peaks/views/zooms/static": "./src/main/views/zooms/static.js",
     "peaks/markers/waveform.points": "./src/main/markers/waveform.points.js",
@@ -81,7 +83,7 @@
   },
   "dependencies": {
     "eventemitter2": "~1.0.0",
-    "konva": "~1.0.0",
+    "konva": "~1.2.2",
     "waveform-data": "^1.5.2"
   }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -314,9 +314,6 @@ define('peaks', [
     instance.waveform = new Waveform(instance);
     instance.waveform.init(buildUi(instance.container));
 
-    // TODO maybe to move in the player object
-    instance.seeking = false;
-
     instance.on('waveformOverviewReady', function() {
       instance.waveform.openZoomView();
 

--- a/src/main.js
+++ b/src/main.js
@@ -399,7 +399,7 @@ define('peaks', [
           /**
            * Return all points
            *
-           * @returns {*|WaveformOverview.playheadLine.points|WaveformZoomView.zoomPlayheadLine.points|points|o.points|n.createUi.points}
+           * @returns {*|WaveformOverview.playheadLine.points|WaveformZoomView.playheadLine.points|points|o.points|n.createUi.points}
            */
           getPoints: function() {
             return self.waveform.points.getPoints();

--- a/src/main/markers/waveform.points.js
+++ b/src/main/markers/waveform.points.js
@@ -142,13 +142,19 @@ define([
     }
   };
 
+  /**
+   * @param {Konva.Group} thisPoint
+   * @param {Point} point
+   */
   WaveformPoints.prototype.pointHandleDrag = function(thisPoint, point) {
-    if (thisPoint.marker.getX() > 0) {
-      var inOffset = thisPoint.view.frameOffset +
-                     thisPoint.marker.getX() +
-                     thisPoint.marker.getWidth();
+    var markerX = thisPoint.marker.getX();
 
-      point.timestamp = thisPoint.view.data.time(inOffset);
+    if (markerX > 0 && markerX < thisPoint.view.width) {
+      var offset = thisPoint.view.frameOffset +
+                   markerX +
+                   thisPoint.marker.getWidth();
+
+      point.timestamp = thisPoint.view.data.time(offset);
     }
 
     this.peaks.emit('points.dragged', point);
@@ -157,7 +163,7 @@ define([
   };
 
   WaveformPoints.prototype.init = function() {
-    this.peaks.on('waveform_zoom_displaying', this.updatePoints.bind(this));
+    this.peaks.on('zoomview.displaying', this.updatePoints.bind(this));
     this.peaks.emit('points.ready');
   };
 

--- a/src/main/markers/waveform.segments.js
+++ b/src/main/markers/waveform.segments.js
@@ -245,8 +245,7 @@ define([
   };
 
   WaveformSegments.prototype.init = function() {
-    this.peaks.on('waveform_zoom_displaying', this.updateSegments.bind(this));
-
+    this.peaks.on('zoomview.displaying', this.updateSegments.bind(this));
     this.peaks.emit('segments.ready');
   };
 

--- a/src/main/player/player.js
+++ b/src/main/player/player.js
@@ -5,7 +5,7 @@
  *
  * @module peaks/player/player
  */
-define(['peaks/waveform/waveform.mixins'], function(mixins) {
+define(['peaks/waveform/waveform.utils'], function(utils) {
   'use strict';
 
   function timeFromPercentage(time, percentage) {
@@ -109,7 +109,7 @@ define(['peaks/waveform/waveform.mixins'], function(mixins) {
   };
 
   Player.prototype.getTimeFromPercentage = function(p) {
-    return mixins.niceTime(this.duration * p / 100, false);
+    return utils.niceTime(this.duration * p / 100, false);
   };
 
   Player.prototype.getSecsFromPercentage = function(p) {

--- a/src/main/views/helpers/mousedraghandler.js
+++ b/src/main/views/helpers/mousedraghandler.js
@@ -1,0 +1,142 @@
+/**
+ * @file
+ *
+ * Defines the {@link MouseDragHandler} class.
+ *
+ * @module peaks/views/helpers/mousedraghandler
+ */
+define(function() {
+  'use strict';
+
+  /**
+   * An object to receive callbacks on mouse drag events. Easch function is
+   * called with the current mouse X position, relative to the stage.
+   *
+   * @typedef {Object} MouseDragHandlers
+   * @global
+   * @property {Function} onMouseDown Mouse down event handler.
+   * @property {Function} onMouseMove Mouse move event handler.
+   * @property {Function} onMouseUp Mouse up event handler.
+   */
+
+  /**
+   * Creates a handler for mouse events to allow interaction with the waveform
+   * views by clicking and dragging the mouse.
+   *
+   * @class
+   * @alias MouseDragHandler
+   *
+   * @param {Konva.Stage} stage
+   * @param {MouseDragHandlers} handlers
+   */
+
+  function MouseDragHandler(stage, handlers) {
+    this._stage     = stage;
+    this._handlers  = handlers;
+    this._dragging  = false;
+    this._mouseDown = this.mouseDown.bind(this);
+    this._mouseUp   = this.mouseUp.bind(this);
+    this._mouseMove = this.mouseMove.bind(this);
+
+    this._stage.on('mousedown', this._mouseDown);
+
+    this._mouseDownClientX = null;
+    this._mouseDownLayerX  = null;
+    this._mousePosLayerX   = null;
+  }
+
+  /**
+   * Mouse down event handler.
+   *
+   * @param {MouseEvent} event
+   */
+
+  MouseDragHandler.prototype.mouseDown = function(event) {
+    if (!event.target) {
+      return;
+    }
+
+    if (event.target.attrs.draggable ||
+        event.target.parent.attrs.draggable) {
+      return;
+    }
+
+    this._mouseDownClientX = event.evt.clientX;
+    this._mouseDownLayerX  = event.evt.layerX;
+
+    if (this._handlers.onMouseDown) {
+      this._handlers.onMouseDown(this._mouseDownLayerX);
+    }
+
+    // Use the window mousemove and mouseup handlers instead of the
+    // Konva.Stage so that we still receive events of the user moves the
+    // mouse outside the stage.
+    window.addEventListener('mousemove', this._mouseMove, false);
+    window.addEventListener('mouseup', this._mouseUp, false);
+    window.addEventListener('blur', this._mouseUp, false);
+  };
+
+  /**
+   * Mouse move event handler.
+   *
+   * @param {MouseEvent} event
+   */
+
+  MouseDragHandler.prototype.mouseMove = function(event) {
+    // Don't update on vertical mouse movement.
+    if (event.clientX === this._mouseDownClientX) {
+      return;
+    }
+
+    this._dragging = true;
+
+    if (this._handlers.onMouseMove) {
+      var layerX = this._getMousePosX(event);
+
+      this._handlers.onMouseMove(layerX);
+    }
+  };
+
+  /**
+   * Mouse up event handler.
+   *
+   * @param {MouseEvent} event
+   */
+
+  MouseDragHandler.prototype.mouseUp = function(event) {
+    if (this._handlers.onMouseUp) {
+      var layerX = this._getMousePosX(event);
+
+      this._handlers.onMouseUp(layerX);
+    }
+
+    window.removeEventListener('mousemove', this._mouseMove, false);
+    window.removeEventListener('mouseup', this._mouseUp, false);
+    window.removeEventListener('blur', this._mouseUp, false);
+
+    this._dragging = false;
+  };
+
+  /**
+   * @returns {Number} The mouse X position for a given mouse event, relative
+   * to the layer that received the mouse down event.
+   *
+   * @param {MouseEvent} event
+   * @private
+   */
+
+  MouseDragHandler.prototype._getMousePosX = function(event) {
+    return event.clientX - this._mouseDownClientX + this._mouseDownLayerX;
+  };
+
+  /**
+   * @returns {Boolean} <code>true</code> if the mouse is being dragged,
+   * i.e., moved with the mouse button held down.
+   */
+
+  MouseDragHandler.prototype.isDragging = function() {
+    return this._dragging;
+  };
+
+  return MouseDragHandler;
+});

--- a/src/main/views/waveform.zoomview.js
+++ b/src/main/views/waveform.zoomview.js
@@ -239,13 +239,13 @@ define([
   };
 
   WaveformZoomView.prototype.createUi = function() {
-    this.zoomPlayheadLine = new Konva.Line({
+    this.playheadLine = new Konva.Line({
       points: [0.5, 0, 0.5, this.height],
       stroke: this.options.playheadColor,
       strokeWidth: 1
     });
 
-    this.zoomPlayheadText = new Konva.Text({
+    this.playheadText = new Konva.Text({
       x: 2,
       y: 12,
       text: '00:00:00',
@@ -255,18 +255,18 @@ define([
       align: 'right'
     });
 
-    this.zoomPlayheadGroup = new Konva.Group({
+    this.playheadGroup = new Konva.Group({
       x: 0,
       y: 0
     });
 
-    this.zoomPlayheadGroup.add(this.zoomPlayheadLine)
-                          .add(this.zoomPlayheadText);
+    this.playheadGroup.add(this.playheadLine)
+                      .add(this.playheadText);
 
-    this.uiLayer.add(this.zoomPlayheadGroup);
+    this.uiLayer.add(this.playheadGroup);
     this.stage.add(this.uiLayer);
 
-    this.zoomPlayheadGroup.moveToTop();
+    this.playheadGroup.moveToTop();
   };
 
   WaveformZoomView.prototype.updateZoomWaveform = function(pixelOffset) {
@@ -302,11 +302,11 @@ define([
     if (display) {
       var remPixels = this.playheadPixel - pixelOffset;
 
-      this.zoomPlayheadGroup.show().setAttr('x', remPixels);
-      this.zoomPlayheadText.setText(mixins.niceTime(this.data.time(this.playheadPixel), false));
+      this.playheadGroup.show().setAttr('x', remPixels);
+      this.playheadText.setText(mixins.niceTime(this.data.time(this.playheadPixel), false));
     }
     else {
-      this.zoomPlayheadGroup.hide();
+      this.playheadGroup.hide();
     }
 
     this.uiLayer.draw();
@@ -388,11 +388,11 @@ define([
       // Place playhead at centre of zoom frame i.e. remPixels = 500
       var remPixels = this.playheadPixel - this.frameOffset;
 
-      this.zoomPlayheadGroup.show().setAttr('x', remPixels);
-      this.zoomPlayheadText.setText(mixins.niceTime(this.data.time(this.playheadPixel), false));
+      this.playheadGroup.show().setAttr('x', remPixels);
+      this.playheadText.setText(mixins.niceTime(this.data.time(this.playheadPixel), false));
     }
     else {
-      this.zoomPlayheadGroup.hide();
+      this.playheadGroup.hide();
     }
 
     this.uiLayer.draw();

--- a/src/main/waveform/waveform.core.js
+++ b/src/main/waveform/waveform.core.js
@@ -207,10 +207,6 @@
     self.peaks.on('user_seek.*', function(time) {
       self.peaks.player.seekBySeconds(time);
     });
-
-    self.peaks.on('user_scrub.*', function(time) {
-      self.peaks.player.seekBySeconds(time);
-    });
   };
 
   Waveform.prototype.destroy = function() {

--- a/src/main/waveform/waveform.utils.js
+++ b/src/main/waveform/waveform.utils.js
@@ -1,0 +1,59 @@
+/**
+ * @file
+ *
+ * Some general utility functions.
+ *
+ * @module peaks/waveform/waveform.utils
+ */
+define(function() {
+  'use strict';
+
+  return {
+
+    /**
+     * Returns a formatted time string.
+     *
+     * @param {int}     time            Time in seconds to be formatted
+     * @param {Boolean} dropHundredths  Don't display hundredths of a second if true
+     * @returns {String}
+     */
+
+    niceTime: function(time, dropHundredths) {
+      var result = [];
+
+      var hundredths = Math.floor((time % 1) * 100);
+      var seconds = Math.floor(time);
+      var minutes = Math.floor(seconds / 60);
+      var hours = Math.floor(minutes / 60);
+
+      if (hours > 0) {
+        result.push(hours); // Hours
+      }
+      result.push(minutes % 60); // Mins
+      result.push(seconds % 60); // Seconds
+
+      for (var i = 0; i < result.length; i++) {
+        var x = result[i];
+
+        if (x < 10) {
+          result[i] = '0' + x;
+        }
+        else {
+          result[i] = x;
+        }
+      }
+
+      result = result.join(':');
+
+      if (!dropHundredths) {
+        if (hundredths < 10) {
+          hundredths = '0' + hundredths;
+        }
+
+        result += '.' + hundredths;
+      }
+
+      return result;
+    }
+  };
+});


### PR DESCRIPTION
This pull request fixes a number of problems with mouse dragging behaviour in the waveform views:

- Dragging to scroll the zoom view causes a jump in position when the mouse pointer moves outside the waveform view (to the left or right)
- Clicking in the overview updates the audio playhead position, but the playhead marker does not move
- Dragging in the overview moves the playhead marker in the zoomview, but does not change the actual audio playhead position, so the two views get out of sync with each other
- Point markers can be dragged beyond the right-hand edge of the waveform view (but not the left-hand edge)