### PR TITLE
1.x.dev segment edit

### DIFF
--- a/src/main/markers/waveform.segments.js
+++ b/src/main/markers/waveform.segments.js
@@ -246,13 +246,13 @@ define([
                      thisSeg.inMarker.getX() +
                      thisSeg.inMarker.getWidth();
 
-      segment.startTime = thisSeg.view.atDataTime(inOffset);
+      segment.startTime = thisSeg.view.atPixelTime(inOffset);
     }
 
     if (thisSeg.outMarker.getX() < thisSeg.view.width) {
       var outOffset = thisSeg.view.frameOffset + thisSeg.outMarker.getX();
 
-      segment.endTime = thisSeg.view.atDataTime(outOffset);
+      segment.endTime = thisSeg.view.atPixelTime(outOffset);
     }
 
     this.peaks.emit('segments.dragged', segment);

--- a/src/main/markers/waveform.segments.js
+++ b/src/main/markers/waveform.segments.js
@@ -216,21 +216,10 @@ define([
     var frameStartOffset = this.peaks.waveform.waveformZoomView.frameOffset;
     var frameEndOffset   = this.peaks.waveform.waveformZoomView.frameOffset + this.peaks.waveform.waveformZoomView.width;
 
-    // if (zoomStartOffset < frameStartOffset) {
-    //   zoomStartOffset = frameStartOffset;
-    // }
-
-    // if (zoomEndOffset > frameEndOffset) {
-    //   zoomEndOffset = frameEndOffset;
-    // }
-
     if (this.peaks.waveform.waveformZoomView.data.segments[segment.id].visible) {
       var segmentData = this.peaks.waveform.waveformZoomView.data.segments[segment.id];
       var offsetLength = segmentData.offset_length;
       var offsetStart  = segmentData.offset_start - this.peaks.waveform.waveformZoomView.data.offset_start;
-
-      // var startPixel = zoomStartOffset - frameStartOffset;
-      // var endPixel   = zoomEndOffset - frameStartOffset;
 
       segment.zoom.show();
 

--- a/src/main/views/waveform.continuous-zoomview.js
+++ b/src/main/views/waveform.continuous-zoomview.js
@@ -470,6 +470,15 @@ define([
   };
 
   /**
+   * Returns the time for a pixel position on the waveform.
+   *
+   * @returns {Number}
+   */
+  WaveformContinuousZoomView.prototype.atPixelTime = function(pixelNumber) {
+    return pixelNumber * this.secondsPerPixel;
+  };
+
+  /**
    * Returns the pixel position for a particuilar position in the audio.
    *
    * @returns {Number}


### PR DESCRIPTION
Editable segments now show and move correctly. There was an issue when dragging that the new pixel position was derived by converting from the dragged pixel position into a time and then back into a pixel position. This caused a precision/rounding error where the derived pixel position of both handles was different from the pixel position of where the handle was dragged to. The effect was both handles of the segment would move uncontrollably when dragging either handle. When dragging the pixel position is now used as the ground truth, instead of the intermediate derived time value