### PR TITLE
Reinstate bower dependencies and provide an alternative demo loading method

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ requirejs.config({
   paths: {
     peaks: 'bower_components/peaks.js/src/main',
     EventEmitter: 'bower_components/eventemitter2/lib/eventemitter2',
-    Konva: 'bower_components/konvajs/konva',
+    konva: 'bower_components/konva/konva',
     'waveform-data': 'bower_components/waveform-data/dist/waveform-data.min'
   }
 });

--- a/bower.json
+++ b/bower.json
@@ -11,7 +11,10 @@
     "test_data"
   ],
   "dependencies": {
-    "requirejs": "~2.1.14"
+    "eventemitter2": "~1.0.0",
+    "konva": "~1.2.2",
+    "requirejs": "~2.1.14",
+    "waveform-data": "~2.0.0"
   },
   "devDependencies": {}
 }

--- a/index.html
+++ b/index.html
@@ -79,9 +79,21 @@
         <button data-action="log-data">Log segments/points</button>
       </div>
 
-      <script src="peaks.js"></script>
       <script>
-        (function(Peaks){
+        function initializeRequireJS() {
+          require.config({
+            paths: {
+              'EventEmitter': 'bower_components/eventemitter2/lib/eventemitter2',
+              'waveform-data': 'https://wzrd.in/standalone/waveform-data@2.0.0?',
+              'peaks': 'src/main',
+              'konva': 'bower_components/konva/konva',
+            }
+          });
+
+          require(['peaks'], initializePeaks);
+        }
+
+        function initializePeaks(Peaks) {
           var options = {
             container: document.getElementById('first-waveform-visualiser-container'),
             mediaElement: document.querySelector('audio'),
@@ -116,7 +128,9 @@
             console.log('Segments', peaksInstance.segments.getSegments());
             console.log('Points', peaksInstance.points.getPoints());
           });
-        })(peaks);
+        };
       </script>
+      <script src="peaks.js" onload="initializePeaks(peaks)"></script>
+      <script src="bower_components/requirejs/require.js" onload="initializeRequireJS()"></script>
   </body>
 </html>


### PR DESCRIPTION
The only drawback is because `waveform-data` does not publish its `dist` folder anymore, there is no "non-build" way to load all bower components.

In the demo, I had to load waveform-data from a CDN which does the browserify build. Although it would not work with the webaudio loader :-(

Two possible solutions:

1. publish again the `dist` folder in git for waveform-data (but I find it ugly and not much compatible with a good CI flow)
1. we don't mind and drop bower in a later version of peaks (it will be a limitation for ES2015 modules anyway, and bower has no much future)