### PR TITLE
Distinguish between played and unplayed portions of the audio

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,9 @@ var options = {
   // Zoom view adapter to use. Valid adapters are: 'animated' (default) and 'static'
   zoomAdapter: 'animated',
 
+  // Fade the played portions of the waveforms
+  playedOverlay: true,
+
   // Array of initial segment objects with startTime and
   // endTime in seconds and a boolean for editable.
   // See below.

--- a/src/main.js
+++ b/src/main.js
@@ -216,7 +216,13 @@ define('peaks', [
       /**
        * Use animation on zoom
        */
-      zoomAdapter: 'animated'
+      zoomAdapter: 'animated',
+
+      /**
+       * A semi-transparent waveform overlay, used to distinguish between
+       * played and unplayed portions of the audio.
+       */
+      playedOverlay: true
     };
 
     /**

--- a/src/main/views/waveform.overview.js
+++ b/src/main/views/waveform.overview.js
@@ -166,6 +166,17 @@ define([
     this.axis = new WaveformAxis(this);
 
     this.uiLayer.add(this.playheadLine);
+
+    if (this.peaks.options.playedOverlay) {
+      this.highlightPlayedRect = new Konva.Rect({
+        height: this.height,
+        fill: '#fff',
+        opacity: 0.5
+      });
+
+      this.uiLayer.add(this.highlightPlayedRect);
+    }
+
     this.stage.add(this.uiLayer);
     this.uiLayer.moveToTop();
   };
@@ -237,6 +248,11 @@ define([
     }
 
     this.playheadLine.setAttr('x', pixel);
+
+    if (this.peaks.options.playedOverlay) {
+      this.highlightPlayedRect.setAttr('width', pixel);
+    }
+
     this.uiLayer.draw();
   };
 

--- a/src/main/views/waveform.zoomview.js
+++ b/src/main/views/waveform.zoomview.js
@@ -104,6 +104,10 @@ define([
 
         if (newFrameOffset !== this.initialFrameOffset) {
           self.peaks.emit('user_scroll.zoomview', newFrameOffset);
+           
+          if (self.peaks.options.playedOverlay) {
+            self.highlightPlayedRect.setAttr('width', self.playheadPixel - newFrameOffset);
+          }
         }
       },
 

--- a/src/main/views/waveform.zoomview.js
+++ b/src/main/views/waveform.zoomview.js
@@ -261,6 +261,17 @@ define([
                       .add(this.playheadText);
 
     this.uiLayer.add(this.playheadGroup);
+
+    if (this.peaks.options.playedOverlay) {
+      this.highlightPlayedRect = new Konva.Rect({
+        height: this.height,
+        fill: '#fff',
+        opacity: 0.5
+      });
+
+      this.uiLayer.add(this.highlightPlayedRect);
+    }
+
     this.stage.add(this.uiLayer);
 
     this.playheadGroup.moveToTop();
@@ -379,6 +390,7 @@ define([
       throw new Error('WaveformZoomView#syncPlayhead passed a pixel index that is not a number: ' + pixelIndex);
     }
 
+    var highlightPlayedRectWidth = pixelIndex;
     var display = (pixelIndex >= this.frameOffset) &&
                   (pixelIndex <= this.frameOffset + this.width);
 
@@ -388,11 +400,17 @@ define([
       // Place playhead at centre of zoom frame i.e. remPixels = 500
       var remPixels = this.playheadPixel - this.frameOffset;
 
+      highlightPlayedRectWidth = remPixels;
+
       this.playheadGroup.show().setAttr('x', remPixels);
       this.playheadText.setText(Utils.niceTime(this.data.time(this.playheadPixel), false));
     }
     else {
       this.playheadGroup.hide();
+    }
+
+    if (this.peaks.options.playedOverlay) {
+      this.highlightPlayedRect.setAttr('width', highlightPlayedRectWidth);
     }
 
     this.uiLayer.draw();

--- a/src/main/views/waveform.zoomview.js
+++ b/src/main/views/waveform.zoomview.js
@@ -104,7 +104,7 @@ define([
 
         if (newFrameOffset !== this.initialFrameOffset) {
           self.peaks.emit('user_scroll.zoomview', newFrameOffset);
-           
+
           if (self.peaks.options.playedOverlay) {
             self.highlightPlayedRect.setAttr('width', self.playheadPixel - newFrameOffset);
           }


### PR DESCRIPTION
![screen shot 2016-12-28 at 9 14 49 pm](https://cloud.githubusercontent.com/assets/1049166/21535474/9a91400e-cd43-11e6-809b-742db5d20164.png)

This adds an optional semi-transparent overlay on top of the played portion of the audio. 

Ideally, I think this would also overlay segments and points, but since the playhead and the rest of the uiLayer are currently underneath the S+P's, it could make sense to bring the whole uiLayer to the forefront (along with this overlay) as part of another PR.

If you think bringing the uiLayer out from behind the S+P's is something that makes sense, I'd be happy to give it a go.
