### PR TITLE
Modified build to output a single UMD module.

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ var p = Peaks.init({ … });
 <script>
 (function(Peaks){
   var p = Peaks.init({ … });
-})(peaks.js);
+})(peaks);
 </script>
 ```
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "peaks.js",
   "version": "0.6.0",
   "description": "Frontend app for displaying audio waveforms",
-  "main": "./index.js",
+  "main": "./peaks.js",
   "contributors": [
     "Chris Finch (https://github.com/chrisfinch)",
     "Thomas Parisot <thomas.parisot@bbc.co.uk> (https://github.com/oncletom)",
@@ -43,9 +43,7 @@
   "license": "LGPL-3.0",
   "scripts": {
     "prebuild": "npm run lint",
-    "build": "npm run build:main && npm run build:standalone",
-    "build:main": "browserify -e ./src/main.js -t deamdify | derequire - > index.js",
-    "build:standalone": "browserify -d -e ./src/main.js -t deamdify -s peaks | exorcist peaks.js.map | derequire - > peaks.js",
+    "build": "browserify -d -e ./src/main.js -t deamdify -s peaks | exorcist peaks.js.map | derequire - > peaks.js",
     "doc": "jsdoc --private --destination docs --recurse src",
     "lint": "eslint src/**/*.js test/**/*.js",
     "pretest": "npm run build",


### PR DESCRIPTION
The build process for _peaks.js_ currently outputs:
- `peaks.js` - A UMD-compliant bundle.
- `index.js` - A CommonJS-compliant bundle.

As described in issue #174, using ES2015-compliant import statements (like those presented in the README.md) will fail as the `package.json` file points to a CommonJS-only bundle.

The CommonJS-compliant bundle is not needed as the [UMD-compliant](https://github.com/umdjs/umd) bundle supersedes it: This bundle works with many module systems (AMD, CommonJS, etc), or falls back to instantiating a global object (peaks) if no module system is found.

This PR modifies the build to output a single UMD module, and updates the README.md installation instructions using the script-tag to reflect this (though I think the steps should not have changed, but the README was incorrect).

Note: I've opened this PR for discussing and validation, please advise where best to put it.
