### PR TITLE
Restore playhead time label on the zoom view

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,10 @@ var options = {
   // Colour of the play head text
   playheadTextColor: '#aaa',
 
+  // Show current time next to the play head
+  // (zoom view only)
+  showPlayheadTime: false,
+
   // the color of a point marker
   pointMarkerColor: '#FF0000',
 

--- a/index.html
+++ b/index.html
@@ -148,7 +148,8 @@
               json: '/test_data/TOL_6min_720p_download.json'
             },
             keyboard: true,
-            pointMarkerColor: '#006eb0'
+            pointMarkerColor: '#006eb0',
+            showPlayheadTime: true
           };
 
           var peaksInstance = Peaks.init(options);

--- a/src/main.js
+++ b/src/main.js
@@ -174,6 +174,12 @@ define('peaks', [
       playheadTextColor:     Colors.gray,
 
       /**
+       * Show current time position by the play head marker
+       * (zoom view only)
+       */
+      showPlayheadTime:      false,
+
+      /**
        * Colour of the axis gridlines
        */
       axisGridlineColor:     '#ccc',

--- a/src/main/views/waveform.zoomview.js
+++ b/src/main/views/waveform.zoomview.js
@@ -96,7 +96,7 @@ define([
 
     var playheadPixel = self.timeToPixels(self.options.mediaElement.currentTime);
 
-    self._playheadLayer = new PlayheadLayer(peaks, self.stage, self, false, playheadPixel);
+    self._playheadLayer = new PlayheadLayer(peaks, self.stage, self, true, playheadPixel);
 
     self.mouseDragHandler = new MouseDragHandler(self.stage, {
       onMouseDown: function(mousePosX) {

--- a/src/main/views/waveform.zoomview.js
+++ b/src/main/views/waveform.zoomview.js
@@ -96,7 +96,13 @@ define([
 
     var playheadPixel = self.timeToPixels(self.options.mediaElement.currentTime);
 
-    self._playheadLayer = new PlayheadLayer(peaks, self.stage, self, true, playheadPixel);
+    self._playheadLayer = new PlayheadLayer(
+        peaks,
+        self.stage,
+        self,
+        self.options.showPlayheadTime,
+        playheadPixel
+    );
 
     self.mouseDragHandler = new MouseDragHandler(self.stage, {
       onMouseDown: function(mousePosX) {


### PR DESCRIPTION
The time label on the playhead used to be visible on the zoomview, I think it was lost with this refactor a6a724894b3291691ae7342b8b62afce6539aac5.  Was that intentional?