### PR TITLE
Keep playhead layer in sync with timeupdate events

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,6 +43,14 @@
         cursor: pointer;
       }
 
+      #seek-time {
+        width: 4em;
+      }
+
+      #controls {
+        float: right;
+      }
+
       .log {
         margin: 0 auto 24px auto;
         width: 1000px;
@@ -88,17 +96,27 @@
       <div id="first-waveform-visualiser-container"></div>
 
       <div id="demo-controls">
-        <audio controls=controls>
-          <source src="/test_data/TOL_6min_720p_download.mp3" type="audio/mpeg">
-          <source src="/test_data/TOL_6min_720p_download.ogg" type="audio/ogg">
-          Your browser does not support the audio element.
-        </audio>
+        <div>
+          <audio controls=controls>
+            <source src="/test_data/TOL_6min_720p_download.mp3" type="audio/mpeg">
+            <source src="/test_data/TOL_6min_720p_download.ogg" type="audio/ogg">
+            Your browser does not support the audio element.
+          </audio>
 
-        <button data-action="zoom-in">Zoom in</button>
-        <button data-action="zoom-out">Zoom out</button>
-        <button data-action="add-segment">Add a Segment at current time</button>
-        <button data-action="add-point">Add a Point at current time</button>
-        <button data-action="log-data">Log segments/points</button>
+          <div id="controls">
+            <div>
+              <button data-action="zoom-in">Zoom in</button>
+              <button data-action="zoom-out">Zoom out</button>
+              <button data-action="add-segment">Add a Segment at current time</button>
+              <button data-action="add-point">Add a Point at current time</button>
+              <button data-action="log-data">Log segments/points</button>
+            </div>
+            <div>
+              <input type="text" id="seek-time" value="0.0">
+              <button data-action="seek">Seek</button>
+            </div>
+          </div>
+        </div>
       </div>
 
       <div class="log">
@@ -233,6 +251,15 @@
           document.querySelector('button[data-action="log-data"]').addEventListener('click', function(event) {
             renderSegments(peaksInstance);
             renderPoints(peaksInstance);
+          });
+
+          document.querySelector('button[data-action="seek"]').addEventListener('click', function(event) {
+            var time = document.getElementById('seek-time').value;
+            var seconds = parseFloat(time);
+
+            if (!Number.isNaN(seconds)) {
+              peaksInstance.player.seek(seconds);
+            }
           });
 
           document.querySelector('body').addEventListener('click', function(event) {

--- a/src/main/views/playhead-layer.js
+++ b/src/main/views/playhead-layer.js
@@ -169,13 +169,13 @@ define([
   PlayheadLayer.prototype.playFrom = function(startTime) {
     var self = this;
 
-    if (!self._useAnimation) {
-      return;
-    }
-
     if (self._playheadLineAnimation) {
       self._playheadLineAnimation.stop();
       self._playheadLineAnimation = null;
+    }
+
+    if (!self._useAnimation) {
+      return;
     }
 
     var lastPlayheadPosition = null;
@@ -184,8 +184,6 @@ define([
       // Elapsed time since animation started (seconds).
       var elapsed = frame.time / 1000;
 
-      // TODO: update playhead position based on player currentTime,
-      // to avoid drift?
       var playheadPosition = self._view.timeToPixels(startTime + elapsed);
 
       if (playheadPosition !== lastPlayheadPosition) {

--- a/src/main/views/playhead-layer.js
+++ b/src/main/views/playhead-layer.js
@@ -36,6 +36,7 @@ define([
 
     this._createPlayhead(showTime, peaks.options.playheadColor, peaks.options.playheadTextColor);
 
+    this.zoomLevelChanged();
     this.syncPlayhead(playheadPixel);
   }
 
@@ -188,6 +189,7 @@ define([
 
       if (playheadPosition !== lastPlayheadPosition) {
         self.syncPlayhead(playheadPosition);
+        lastPlayheadPosition = playheadPosition;
       }
     }, self._playheadLayer);
 

--- a/src/main/views/waveform.zoomview.js
+++ b/src/main/views/waveform.zoomview.js
@@ -382,9 +382,10 @@ define([
   };
 
   WaveformZoomView.prototype.updatePlayheadTime = function(time) {
-    var frameIndex = this.timeToPixels(time);
+    var pixelIndex = this.timeToPixels(time);
 
-    this._playheadLayer.syncPlayhead(frameIndex);
+    this._playheadLayer.syncPlayhead(pixelIndex);
+
     if (this._playing) {
       this._playheadLayer.playFrom(time);
     }

--- a/src/main/views/waveform.zoomview.js
+++ b/src/main/views/waveform.zoomview.js
@@ -128,13 +128,9 @@ define([
           var time = self.pixelsToTime(pixelIndex);
 
           self.updateWaveform(pixelIndex - mouseDownX);
-          self._playheadLayer.syncPlayhead(pixelIndex);
+          self.updatePlayheadTime(time);
 
           self.peaks.player.seek(time);
-
-          if (self._playing) {
-            self._playheadLayer.playFrom(time);
-          }
         }
       }
     });
@@ -146,9 +142,9 @@ define([
         return;
       }
 
-      var pixelIndex = self.timeToPixels(time);
+      self.updatePlayheadTime(time);
 
-      self._playheadLayer.syncPlayhead(pixelIndex);
+      var pixelIndex = self.timeToPixels(time);
 
       // Check for the playhead reaching the right-hand side of the window.
 
@@ -173,11 +169,7 @@ define([
       var frameIndex = self.timeToPixels(time);
 
       self.updateWaveform(frameIndex - Math.floor(self.width / 2));
-      self._playheadLayer.syncPlayhead(frameIndex);
-
-      if (self._playing) {
-        self._playheadLayer.playFrom(time);
-      }
+      self.updatePlayheadTime(time);
     });
 
     self.peaks.on('user_scroll.zoomview', function(pixelOffset) {
@@ -186,7 +178,7 @@ define([
 
     self.peaks.on('player_play', function(time) {
       self._playing = true;
-      self._playheadLayer.playFrom(time);
+      self.updatePlayheadTime(time);
     });
 
     self.peaks.on('player_pause', function(time) {
@@ -271,13 +263,8 @@ define([
 
     this._playheadLayer.zoomLevelChanged();
 
-    // Update the playhead position after zooming. This is done automatically
-    // by the playhead animation if the media is playing.
-    if (!this._playing) {
-      var playheadPixel = this.timeToPixels(currentTime);
-
-      this._playheadLayer.syncPlayhead(playheadPixel);
-    }
+    // Update the playhead position after zooming.
+    this.updatePlayheadTime(currentTime);
 
     // var adapter = this.createZoomAdapter(currentScale, previousScale);
 
@@ -392,6 +379,15 @@ define([
     this._segmentsLayer.updateSegments(frameStartTime, frameEndTime);
 
     this.peaks.emit('zoomview.displaying', frameStartTime, frameEndTime);
+  };
+
+  WaveformZoomView.prototype.updatePlayheadTime = function(time) {
+    var frameIndex = this.timeToPixels(time);
+
+    this._playheadLayer.syncPlayhead(frameIndex);
+    if (this._playing) {
+      this._playheadLayer.playFrom(time);
+    }
   };
 
   WaveformZoomView.prototype.beginZoom = function() {


### PR DESCRIPTION
Currently, when zoomview receives a timeupdate event from the player, it calls `_playheadLayer.syncPlayhead`.  However, if a play animation is present (from `PlayheadLayer.playFrom`), that will immediately call syncPlayhead again with the time value based on when playFrom was last called.

This commit calls playFrom on each timeupdate event, which eliminates drift and ensures that the playhead is in sync with any changes made to the audio node (eg if the audio node is playing and you change audio.currentTime externally to peaks.js).

WDYT?