### PR TITLE
Fix the overview playhead not keeping in sync following a seek

### DIFF
--- a/src/main/views/waveform.overview.js
+++ b/src/main/views/waveform.overview.js
@@ -90,11 +90,7 @@ define([
 
         var time = self.pixelsToTime(mousePosX);
 
-        self._playheadLayer.syncPlayhead(mousePosX);
-
-        if (self._playing) {
-          self._playheadLayer.playFrom(time);
-        }
+        self.updatePlayheadTime(time);
 
         self.peaks.emit('user_seek', time);
       },
@@ -106,11 +102,7 @@ define([
 
         // Update the playhead position. This gives a smoother visual update
         // than if we only use the player_time_update event.
-        self._playheadLayer.syncPlayhead(mousePosX);
-
-        if (self._playing) {
-          self._playheadLayer.playFrom(time);
-        }
+        self.updatePlayheadTime(time);
 
         self.peaks.emit('user_seek', time);
       }
@@ -130,9 +122,7 @@ define([
     });
 
     peaks.on('player_time_update', function(time) {
-      var pixelIndex = self.timeToPixels(time);
-
-      self._playheadLayer.syncPlayhead(pixelIndex);
+      self.updatePlayheadTime(time);
     });
 
     peaks.on('zoomview.displaying', function(startTime, endTime) {
@@ -238,6 +228,16 @@ define([
     });
 
     this.highlightLayer.draw();
+  };
+
+  WaveformOverview.prototype.updatePlayheadTime = function(time) {
+    var pixelIndex = this.timeToPixels(time);
+
+    this._playheadLayer.syncPlayhead(pixelIndex);
+
+    if (this._playing) {
+      this._playheadLayer.playFrom(time);
+    }
   };
 
   /**


### PR DESCRIPTION
Sorry - one more fix for the playhead animations. 

If you play and then seek by clicking in the `zoomview`, the playhead in the `overview` view jumps around.  It's keeping the original play animation but also receiving timeupdate events for a different time.  This commit ensures the two are in sync.

It wasn't visible in my original demo page because it was a long audio file, so the overview waveform was extremely zoomed out.  It's more obvious with a shorter clip here - https://codepen.io/jdelStrother/pen/QOaVax?editors=1010.

[WaveformOverview & WaveformZoomview are building up quite a bit of duplication.  How do you feel about extracting the duplication to a shared set of functions?]