### PR TITLE
Replace playhead Konva animations with requestAnimationFrame

### DIFF
--- a/src/main/views/waveform.overview.js
+++ b/src/main/views/waveform.overview.js
@@ -112,13 +112,11 @@ define([
 
     self.peaks.on('player_play', function(time) {
       self._playing = true;
-      self._playheadLayer.playFrom(time);
+      self.updatePlayheadTime(time);
     });
 
     self.peaks.on('player_pause', function(time) {
       self._playing = false;
-
-      self._playheadLayer.stop(time);
     });
 
     peaks.on('player_time_update', function(time) {
@@ -138,8 +136,6 @@ define([
       self.data = self.originalWaveformData.resample(self.width);
       self.stage.setWidth(self.width);
       self.container.removeAttribute('hidden');
-
-      self._playheadLayer.zoomLevelChanged();
     });
 
     peaks.emit('waveform_ready.overview', this);
@@ -234,10 +230,6 @@ define([
     var pixelIndex = this.timeToPixels(time);
 
     this._playheadLayer.syncPlayhead(pixelIndex);
-
-    if (this._playing) {
-      this._playheadLayer.playFrom(time);
-    }
   };
 
   /**

--- a/src/main/views/waveform.overview.js
+++ b/src/main/views/waveform.overview.js
@@ -82,7 +82,6 @@ define([
     var playheadPixel = self.timeToPixels(self.options.mediaElement.currentTime);
 
     self._playheadLayer = new PlayheadLayer(peaks, self.stage, self, false, playheadPixel);
-    self._playing = false;
 
     self.mouseDragHandler = new MouseDragHandler(self.stage, {
       onMouseDown: function(mousePosX) {
@@ -111,12 +110,7 @@ define([
     // Events
 
     self.peaks.on('player_play', function(time) {
-      self._playing = true;
       self.updatePlayheadTime(time);
-    });
-
-    self.peaks.on('player_pause', function(time) {
-      self._playing = false;
     });
 
     peaks.on('player_time_update', function(time) {
@@ -230,14 +224,6 @@ define([
     var pixelIndex = this.timeToPixels(time);
 
     this._playheadLayer.syncPlayhead(pixelIndex);
-  };
-
-  /**
-   * @returns <code>true</code> if the audio is currently playing.
-   */
-
-  WaveformOverview.prototype.isPlaying = function() {
-    return this._playing;
   };
 
   WaveformOverview.prototype.destroy = function() {

--- a/src/main/views/waveform.zoomview.js
+++ b/src/main/views/waveform.zoomview.js
@@ -189,8 +189,6 @@ define([
 
     self.peaks.on('player_pause', function(time) {
       self._playing = false;
-
-      self._playheadLayer.stop(time);
     });
 
     self.peaks.on('zoom.update', function(currentScale, previousScale) {
@@ -266,8 +264,6 @@ define([
     this.frameOffset = apexPixel - playheadOffsetPixels;
 
     this.updateWaveform(this.frameOffset);
-
-    this._playheadLayer.zoomLevelChanged();
 
     // Update the playhead position after zooming.
     this.updatePlayheadTime(currentTime);
@@ -391,10 +387,6 @@ define([
     var pixelIndex = this.timeToPixels(time);
 
     this._playheadLayer.syncPlayhead(pixelIndex);
-
-    if (this._playing) {
-      this._playheadLayer.playFrom(time);
-    }
   };
 
   WaveformZoomView.prototype.beginZoom = function() {

--- a/src/main/views/waveform.zoomview.js
+++ b/src/main/views/waveform.zoomview.js
@@ -50,7 +50,6 @@ define([
 
     self.options = peaks.options;
 
-    self._playing = false;
     self.playheadVisible = false;
 
     self.data = null;
@@ -183,12 +182,7 @@ define([
     });
 
     self.peaks.on('player_play', function(time) {
-      self._playing = true;
       self.updatePlayheadTime(time);
-    });
-
-    self.peaks.on('player_pause', function(time) {
-      self._playing = false;
     });
 
     self.peaks.on('zoom.update', function(currentScale, previousScale) {
@@ -414,14 +408,6 @@ define([
     var time = this.peaks.player.getCurrentTime();
 
     this.seekFrame(this.timeToPixels(time));
-  };
-
-  /**
-   * @returns <code>true</code> if the audio is currently playing.
-   */
-
-  WaveformZoomView.prototype.isPlaying = function() {
-    return this._playing;
   };
 
   WaveformZoomView.prototype.destroy = function() {


### PR DESCRIPTION
As discussed in #205, HTML5 audio emits `timeupdate` events at a very low frequency - around 250ms in Chrome.
This PR uses requestAnimationFrame to continually fire `player_time_update` events during playback.  This removes the need for a custom animation in the playhead layer, and makes any jumps in currentTime much less noticeable.

WDYT?