### PR TITLE
Added pointer.mouseover and pointer.mouseleave events

### DIFF
--- a/README.md
+++ b/README.md
@@ -623,6 +623,8 @@ Peaks instances emit events to enable you to extend its behaviour according to y
 | `points.remove`           | `Array<Point> points` |
 | `points.remove_all`       | (none)                |
 | `points.dragged`          | `Point point`         |
+| `points.mouseenter`       | `Point point`         |
+| `points.mouseleave`       | `Point point`         |
 
 # Building Peaks.js
 

--- a/src/main/views/points-layer.js
+++ b/src/main/views/points-layer.js
@@ -152,20 +152,18 @@ define([
   };
 
   /**
-   * @param {Konva.Group} pointGroup
    * @param {Point} point
    */
 
-  PointsLayer.prototype._onPointHandleMouseOver = function(pointGroup, point) {
+  PointsLayer.prototype._onPointHandleMouseOver = function(point) {
     this._peaks.emit('points.mouseover', point);
   };
 
   /**
-   * @param {Konva.Group} pointGroup
    * @param {Point} point
    */
 
-  PointsLayer.prototype._onPointHandleMouseLeave = function(pointGroup, point) {
+  PointsLayer.prototype._onPointHandleMouseLeave = function(point) {
     this._peaks.emit('points.mouseleave', point);
   };
 

--- a/src/main/views/points-layer.js
+++ b/src/main/views/points-layer.js
@@ -104,7 +104,9 @@ define([
       layer:       this._layer,
       onDrag:      editable ? this._onPointHandleDrag.bind(this) : null,
       onDblClick:  this._peaks.options.pointDblClickHandler,
-      onDragEnd:   editable ? this._peaks.options.pointDragEndHandler : null
+      onDragEnd:   editable ? this._peaks.options.pointDragEndHandler : null,
+      onMouseOver: this._onPointHandleMouseOver.bind(this),
+      onMouseLeave: this._onPointHandleMouseLeave.bind(this)
     });
 
     pointGroup.add(pointGroup.marker);
@@ -147,6 +149,24 @@ define([
     }
 
     this._peaks.emit('points.dragged', point);
+  };
+
+  /**
+   * @param {Konva.Group} pointGroup
+   * @param {Point} point
+   */
+
+  PointsLayer.prototype._onPointHandleMouseOver = function(pointGroup, point) {
+    this._peaks.emit('points.mouseover', point);
+  };
+
+  /**
+   * @param {Konva.Group} pointGroup
+   * @param {Point} point
+   */
+
+  PointsLayer.prototype._onPointHandleMouseLeave = function(pointGroup, point) {
+    this._peaks.emit('points.mouseleave', point);
   };
 
   /**

--- a/src/main/waveform/waveform.mixins.js
+++ b/src/main/waveform/waveform.mixins.js
@@ -163,6 +163,8 @@ define(['konva'], function(Konva) {
    * @property {Function} onDrag Callback after drag completed.
    * @property {Function} onDblClick
    * @property {Function} onDragEnd
+   * @property {Function} onMouseOver
+   * @property {Function} onMouseLeave
    */
 
   /**

--- a/src/main/waveform/waveform.mixins.js
+++ b/src/main/waveform/waveform.mixins.js
@@ -206,6 +206,18 @@ define(['konva'], function(Konva) {
       });
     }
 
+    if (options.onMouseOver) {
+      group.on('mouseover', function(event) {
+        options.onMouseOver(options.point);
+      });
+    }
+
+    if (options.onMouseLeave) {
+      group.on('mouseout', function(event) {
+        options.onMouseLeave(options.point);
+      });
+    }
+
     // Label
     var text = null;
 


### PR DESCRIPTION
This PR adds support for two new Point events: `points.mouseover` and `points.mouseleave`.