### PR TITLE
Fix dragmove event and add live updating of point when dragging.

### DIFF
--- a/src/main/views/points-layer.js
+++ b/src/main/views/points-layer.js
@@ -77,6 +77,11 @@ define([
       self._layer.draw();
     });
 
+    this._peaks.on('points.dragmove', function(point) {
+      self._updatePoint(point);
+      self._layer.draw();
+    });
+
     this._peaks.on('points.dragged', function(point) {
       self._updatePoint(point);
       self._layer.draw();

--- a/src/main/waveform/waveform.mixins.js
+++ b/src/main/waveform/waveform.mixins.js
@@ -199,7 +199,7 @@ define(['konva'], function(Konva) {
 
     if (options.onDragMove) {
       group.on('dragmove', function(event) {
-        options.onDragMove(options.point);
+        options.onDragMove(options.pointGroup, options.point);
       });
     }
 


### PR DESCRIPTION
Good morning, this should fix this error:

> Uncaught TypeError: Cannot read property 'getX' of undefined
    at PointsLayer._onPointHandleDragMove (points-layer.js:72)
    at Konva.Group.<anonymous> (waveform.mixins.js:115)
    at Konva.Group._fire (konva.js:4329)
    at Konva.Group._fireAndBubble (konva.js:4291)
    at Konva.Group.fire (konva.js:3772)
    at HTMLHtmlElement._drag (konva.js:12447)

and also makes the point marker live moving in the overview while dragging in zoomview.
Thanks 