### PR TITLE
fix init error in safari

### DIFF
--- a/src/main/waveform/waveform.core.js
+++ b/src/main/waveform/waveform.core.js
@@ -161,7 +161,8 @@
   Waveform.prototype._buildWaveformDataUsingWebAudio = function(options) {
     var self = this;
 
-    if (!(options.audioContext instanceof AudioContext)) {
+    var audioContext = window.AudioContext || window.webkitAudioContext;
+    if (!(options.audioContext instanceof audioContext)) {
       // eslint-disable-next-line max-len
       throw new TypeError('Peaks.init(): The audioContext option must be a valid AudioContext');
     }


### PR DESCRIPTION
ReferenceError: Can't find variable: AudioContext