### PR TITLE
When use `AudioContext`, only call requestAudioAndBuildWaveformData once

### DIFF
--- a/src/main/waveform/waveform.core.js
+++ b/src/main/waveform/waveform.core.js
@@ -186,7 +186,7 @@
       );
     }
     else {
-      self.peaks.on('player_canplay', function(player) {
+      self.peaks.once('player_canplay', function(player) {
         self._requestAudioAndBuildWaveformData(
           player.getCurrentSource(),
           options.audioContext,


### PR DESCRIPTION
When use `AudioContext` to generate the Peak,  and the `mediaSourceUrl` is null at the first time,  the `canplay` event listener will be bind. 
As we know, `canplay` event will be emit not only once, it can be emit so many times when we seek the video. 
https://github.com/bbc/peaks.js/blob/a7f11efe8fee6b40d9fadfb4ed17c47c68efde57/src/main/waveform/waveform.core.js#L179-L196
This code will cause `WaveformData` rebuild many times, we will not only lost the points marked before, but also each rebuild will add  many event listeners, may be memory leak at last. 
Add the `canplay` event listener by `once` can fix the problem maybe.

#208 