### PR TITLE
ci: test Node.js 6, 8, 10 and 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: node_js
 node_js:
-- v6
-- v8
+- '6'
+- '8'
+- '10'
+- 'node'
 sudo: false
 cache:
   directories:


### PR DESCRIPTION
Currently Node.js 6, 8 and 10 are LTS and 11 (`node`) is stable.

https://github.com/nodejs/Release/blob/master/README.md