### PR TITLE
supress mouse events event after touch events

### DIFF
--- a/src/main/views/helpers/mousedraghandler.js
+++ b/src/main/views/helpers/mousedraghandler.js
@@ -129,6 +129,9 @@ define(function() {
 
     if (event.type === 'touchend') {
       clientX = Math.floor(event.changedTouches[0].clientX);
+      if (event.cancelable) {
+        event.preventDefault();
+      }
     }
     else {
       clientX = event.clientX;


### PR DESCRIPTION
call event.preventDefault() in touchend event handler to prevent the handling of browser generated mouse events on mobile devices, see https://github.com/bbc/peaks.js/issues/251