### PR TITLE
allow glob for testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -788,9 +788,12 @@ The output of the build is a file named `peaks.js`, alongside its associated [so
 
 # Testing
 
-`npm test` should work for simple one time testing.
+Tests run in Karma using Mocha + Chai + Sinon.
 
-If you are developing and want to repeatedly run tests in a browser on your machine simply launch `npm run test-watch`.
+ - `npm test` should work for simple one time testing.
+ - `npm test -- --glob %pattern%` to run selected test suite(s) only
+ - `npm run test-watch` if you are developing and want to repeatedly run tests in a browser on your machine.
+ - `npm run test-watch -- --glob %pattern%` is also available
 
 # License
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,4 +1,5 @@
 'use strict';
+/* eslint-disable */
 
 function filterBrowsers(browsers, re) {
   return Object.keys(browsers).filter(function(key) {
@@ -9,6 +10,7 @@ function filterBrowsers(browsers, re) {
 module.exports = function(config) {
   var isCI = Boolean(process.env.CI) && Boolean(process.env.BROWSER_STACK_ACCESS_KEY);
 
+  var glob = config.glob || '**/*.js'
   // Karma configuration
   config.set({
     // The root path location that will be used to resolve all relative paths
@@ -38,7 +40,7 @@ module.exports = function(config) {
       { pattern: 'test/test_img/*', included: false },
       { pattern: 'test_data/*', included: false },
       { pattern: 'test_data/sample.{dat,json}', included: false, served: true },
-      { pattern: 'test/unit/**/*.js', included: true }
+      { pattern: 'test/unit/'+glob, included: true }
     ],
 
     mime: {

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,15 +1,15 @@
 'use strict';
-/* global process, module */
+/* eslint-env node */
+
+function filterBrowsers(browsers, re) {
+  return Object.keys(browsers).filter(function(key) {
+    return re.test(key);
+  });
+}
 
 module.exports = function(config) {
   var isCI = Boolean(process.env.CI) && Boolean(process.env.BROWSER_STACK_ACCESS_KEY);
   var glob = config.glob || '**/*.js';
-
-  function filterBrowsers(browsers, re) {
-    return Object.keys(browsers).filter(function(key) {
-      return re.test(key);
-    });
-  }
 
   // Karma configuration
   config.set({

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,16 +1,16 @@
 'use strict';
-/* eslint-disable */
-
-function filterBrowsers(browsers, re) {
-  return Object.keys(browsers).filter(function(key) {
-    return re.test(key);
-  });
-}
+/* global process, module */
 
 module.exports = function(config) {
   var isCI = Boolean(process.env.CI) && Boolean(process.env.BROWSER_STACK_ACCESS_KEY);
+  var glob = config.glob || '**/*.js';
 
-  var glob = config.glob || '**/*.js'
+  function filterBrowsers(browsers, re) {
+    return Object.keys(browsers).filter(function(key) {
+      return re.test(key);
+    });
+  }
+
   // Karma configuration
   config.set({
     // The root path location that will be used to resolve all relative paths
@@ -40,7 +40,7 @@ module.exports = function(config) {
       { pattern: 'test/test_img/*', included: false },
       { pattern: 'test_data/*', included: false },
       { pattern: 'test_data/sample.{dat,json}', included: false, served: true },
-      { pattern: 'test/unit/'+glob, included: true }
+      { pattern: 'test/unit/' + glob, included: true }
     ],
 
     mime: {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "build": "browserify -d -e ./src/main.js -t deamdify -s peaks | exorcist peaks.js.map | derequire - > peaks.js",
     "postbuild": "cp peaks.js demo && cp peaks.js.map demo",
     "doc": "jsdoc --private --destination docs --recurse src",
-    "lint": "eslint src/**/*.js test/**/*.js",
+    "lint": "eslint src/**/*.js test/**/*.js karma.conf.js",
     "pretest": "npm run build",
     "test": "./node_modules/karma/bin/karma start",
     "test-watch": "npm test -- --auto-watch --no-single-run",

--- a/test/unit/api-player-spec.js
+++ b/test/unit/api-player-spec.js
@@ -1,5 +1,6 @@
 'use strict';
 
+require('./setup.js');
 var Peaks = require('../../src/main');
 
 describe('Peaks.player', function() {

--- a/test/unit/api-player-spec.js
+++ b/test/unit/api-player-spec.js
@@ -1,6 +1,7 @@
 'use strict';
 
-require('./setup.js');
+require('./setup');
+
 var Peaks = require('../../src/main');
 
 describe('Peaks.player', function() {

--- a/test/unit/api-points-spec.js
+++ b/test/unit/api-points-spec.js
@@ -1,5 +1,6 @@
 'use strict';
 
+require('./setup.js');
 var Peaks = require('../../src/main');
 var Point = require('../../src/main/markers/point');
 

--- a/test/unit/api-points-spec.js
+++ b/test/unit/api-points-spec.js
@@ -1,6 +1,7 @@
 'use strict';
 
-require('./setup.js');
+require('./setup');
+
 var Peaks = require('../../src/main');
 var Point = require('../../src/main/markers/point');
 

--- a/test/unit/api-segments-spec.js
+++ b/test/unit/api-segments-spec.js
@@ -1,5 +1,6 @@
 'use strict';
 
+require('./setup.js');
 var Peaks = require('../../src/main');
 var Segment = require('../../src/main/markers/segment');
 

--- a/test/unit/api-segments-spec.js
+++ b/test/unit/api-segments-spec.js
@@ -1,6 +1,7 @@
 'use strict';
 
-require('./setup.js');
+require('./setup');
+
 var Peaks = require('../../src/main');
 var Segment = require('../../src/main/markers/segment');
 

--- a/test/unit/api-spec.js
+++ b/test/unit/api-spec.js
@@ -1,6 +1,7 @@
 'use strict';
 
-require('./setup.js');
+require('./setup');
+
 var Peaks = require('../../src/main');
 
 var TestAudioContext = window.AudioContext || window.mozAudioContext || window.webkitAudioContext;

--- a/test/unit/api-spec.js
+++ b/test/unit/api-spec.js
@@ -1,5 +1,6 @@
 'use strict';
 
+require('./setup.js');
 var Peaks = require('../../src/main');
 
 var TestAudioContext = window.AudioContext || window.mozAudioContext || window.webkitAudioContext;

--- a/test/unit/api-view-apec.js
+++ b/test/unit/api-view-apec.js
@@ -1,5 +1,6 @@
 'use strict';
 
+require('./setup.js');
 var Peaks = require('../../src/main');
 
 describe('WaveformView', function() {

--- a/test/unit/api-view-apec.js
+++ b/test/unit/api-view-apec.js
@@ -1,6 +1,7 @@
 'use strict';
 
-require('./setup.js');
+require('./setup');
+
 var Peaks = require('../../src/main');
 
 describe('WaveformView', function() {

--- a/test/unit/api-views-spec.js
+++ b/test/unit/api-views-spec.js
@@ -1,6 +1,7 @@
 'use strict';
 
-require('./setup.js');
+require('./setup');
+
 var Peaks = require('../../src/main');
 var WaveformOverview = require('../../src/main/views/waveform.overview');
 var WaveformZoomView = require('../../src/main/views/waveform.zoomview');

--- a/test/unit/api-views-spec.js
+++ b/test/unit/api-views-spec.js
@@ -1,5 +1,6 @@
 'use strict';
 
+require('./setup.js');
 var Peaks = require('../../src/main');
 var WaveformOverview = require('../../src/main/views/waveform.overview');
 var WaveformZoomView = require('../../src/main/views/waveform.zoomview');

--- a/test/unit/api-zoom-spec.js
+++ b/test/unit/api-zoom-spec.js
@@ -1,5 +1,6 @@
 'use strict';
 
+require('./setup.js');
 var Peaks = require('../../src/main');
 
 describe('Peaks.zoom', function() {

--- a/test/unit/api-zoom-spec.js
+++ b/test/unit/api-zoom-spec.js
@@ -1,6 +1,7 @@
 'use strict';
 
-require('./setup.js');
+require('./setup');
+
 var Peaks = require('../../src/main');
 
 describe('Peaks.zoom', function() {

--- a/test/unit/point-spec.js
+++ b/test/unit/point-spec.js
@@ -1,5 +1,6 @@
 'use strict';
 
+require('./setup.js');
 var Peaks = require('../../src/main');
 var Point = require('../../src/main/markers/point');
 

--- a/test/unit/point-spec.js
+++ b/test/unit/point-spec.js
@@ -1,6 +1,7 @@
 'use strict';
 
-require('./setup.js');
+require('./setup');
+
 var Peaks = require('../../src/main');
 var Point = require('../../src/main/markers/point');
 

--- a/test/unit/segment-spec.js
+++ b/test/unit/segment-spec.js
@@ -1,5 +1,6 @@
 'use strict';
 
+require('./setup.js');
 var Peaks = require('../../src/main');
 var Segment = require('../../src/main/markers/segment');
 

--- a/test/unit/segment-spec.js
+++ b/test/unit/segment-spec.js
@@ -1,6 +1,7 @@
 'use strict';
 
-require('./setup.js');
+require('./setup');
+
 var Peaks = require('../../src/main');
 var Segment = require('../../src/main/markers/segment');
 

--- a/test/unit/utils-spec.js
+++ b/test/unit/utils-spec.js
@@ -1,6 +1,7 @@
 'use strict';
 
-require('./setup.js');
+require('./setup');
+
 var Utils = require('../../src/main/waveform/waveform.utils');
 
 describe('Utils', function() {

--- a/test/unit/utils-spec.js
+++ b/test/unit/utils-spec.js
@@ -1,5 +1,6 @@
 'use strict';
 
+require('./setup.js');
 var Utils = require('../../src/main/waveform/waveform.utils');
 
 describe('Utils', function() {

--- a/test/unit/waveform-builder-spec.js
+++ b/test/unit/waveform-builder-spec.js
@@ -1,6 +1,7 @@
 'use strict';
 
-require('./setup.js');
+require('./setup');
+
 var WaveformBuilder = require('../../src/main/waveform/waveform-builder');
 var WaveformData = require('waveform-data');
 

--- a/test/unit/waveform-builder-spec.js
+++ b/test/unit/waveform-builder-spec.js
@@ -1,5 +1,6 @@
 'use strict';
 
+require('./setup.js');
 var WaveformBuilder = require('../../src/main/waveform/waveform-builder');
 var WaveformData = require('waveform-data');
 

--- a/test/unit/waveform-segments-spec.js
+++ b/test/unit/waveform-segments-spec.js
@@ -1,5 +1,6 @@
 'use strict';
 
+require('./setup.js');
 var Peaks = require('../../src/main');
 
 describe('SegmentsLayer', function() {

--- a/test/unit/waveform-segments-spec.js
+++ b/test/unit/waveform-segments-spec.js
@@ -1,6 +1,7 @@
 'use strict';
 
-require('./setup.js');
+require('./setup');
+
 var Peaks = require('../../src/main');
 
 describe('SegmentsLayer', function() {


### PR DESCRIPTION
close #266 - allows running selected test suites by command line argument

examples:

```
npm test -- --glob=api-player-spec.js
```

```
npm run test-watch -- --glob=api-player-spec.js
```

```
npm test -- --glob=waveform*.js
```