### PR TITLE
Updated README to include install note

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ The [demo](demo) folder contains some working examples of Peaks.js in use. To vi
 ```bash
 git clone git@github.com:bbc/peaks.js.git
 cd peaks.js
+npm install
 npm start
 ```
 


### PR DESCRIPTION
This is a minor README change to let the user know that they can't run the demos with (`npm start`) without installing dependencies first (`npm install`).