### PR TITLE
Update typescript definitions for 0.14.3 changes

### DIFF
--- a/peaks.js.d.ts
+++ b/peaks.js.d.ts
@@ -113,7 +113,10 @@ declare module 'peaks.js' {
     overviewWaveformColor?: string;
     // Colour for the overview waveform rectangle
     // that shows what the zoom view shows
-    overviewHighlightRectangleColor?: string;
+    overviewHighlightColor?: string;
+    // The default number of pixels from the top and bottom of the canvas
+    // that the overviewHighlight takes up
+    overviewHighlightOffset?: number;
     // Colour for segments on the waveform
     segmentColor?: string;
     // Colour of the play head


### PR DESCRIPTION
The changes from version 0.14.3 were missing.
- overviewHighlightOffset
- overviewHighlightRectangleColor -> overviewHighlightColor