### PR TITLE
Zoom API

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ You can read more about the project and see a demo [here](https://waveform.proto
     - [view.enableAutoScroll()](#viewenableautoscrollenable)
     - [view.enableMarkerEditing()](#viewenablemarkereditingenable)
     - [view.fitToContainer()](#viewfittocontainer)
+    - [view.setZoom()](#viewsetzoomoptions)
   - [Zoom API](#zoom-api)
     - [instance.zoom.zoomIn()](#instancezoomzoomin)
     - [instance.zoom.zoomOut()](#instancezoomzoomout)
@@ -703,15 +704,39 @@ instance.segments.add({
 
 ### `view.fitToContainer()`
 
-Resizes the waveform view to fit the container. You should call this function
-after changing the height of the container HTML element.
+Resizes the waveform view to fit the container. You should call this method
+after changing the width or height of the container HTML element.
+
+If the zoom level has been set to a number of seconds or `'auto'`, the waveform
+will be automatically rescaled to fit the container width.
 
 ```js
 const container = document.getElementById('zoomview-container');
 const view = instance.views.getView('zoomview');
 
-container.setAttribute('style', 'height:300px');
+container.setAttribute('style', 'height: 300px');
 view.fitToContainer();
+```
+
+### `view.setZoom(options)`
+
+Changes the zoom level of the zoomable waveform view.
+
+This method gives applications greater control over the zoom level than the
+older [Zoom API](#zoom-api) methods.
+
+The `options` parameter is an object with one of the following keys:
+
+* `scale`: Sets the zoom level, in samples per pixel.
+* `seconds`: Sets the zoom level to fit the given number of seconds in the available width.
+
+Either option may have the value `'auto'`, which fits the entire waveform to the container width.
+
+```js
+const view = instance.views.getView('zoomview');
+view.setZoom({ scale: 512 }); // samples per pixel
+view.setZoom({ seconds: 5.0 });
+view.setZoom({ seconds: 'auto' });
 ```
 
 ## Zoom API
@@ -743,13 +768,17 @@ instance.zoom.zoomIn(); // zoom level is now 512 again
 
 ### `instance.zoom.setZoom(index)`
 
-Sets the zoom level to the element in the `options.zoomLevels` array at index `index`.
+Changes the zoom level of the zoomable waveform view to the element in the
+`options.zoomLevels` array at index `index`.
 
 ```js
 const instance = Peaks.init({ ..., zoomLevels: [512, 1024, 2048, 4096] });
 
 instance.zoom.setZoom(3); // zoom level is now 4096
 ```
+
+See also [view.setZoom()](#viewsetzoomoptions), which offers a more flexible
+way of setting the zoom level.
 
 ### `instance.zoom.getZoom()`
 

--- a/demo/zoomable-waveform.html
+++ b/demo/zoomable-waveform.html
@@ -6,11 +6,8 @@
     <style>
       body {
         font-family: 'Helvetica neue', Helvetica, Arial, sans-serif;
-      }
-
-      #titles, #waveform-container {
-        margin: 24px auto;
-        width: 1000px;
+        display: grid;
+        grid-template-columns: 200px auto 200px;
       }
 
       #zoomview-container {
@@ -22,9 +19,12 @@
         height: 200px;
       }
 
+      #zoomview-container .konvajs-content {
+        width: 100% !important;
+      }
+
       #demo-controls {
         margin: 0 auto 24px auto;
-        width: 1000px;
         display: flex;
         align-items: center;
       }
@@ -50,7 +50,9 @@
     </style>
   </head>
   <body>
-    <div id="titles">
+    <div id="margin-left">
+    </div>
+    <div id="main">
       <h1>Peaks.js</h1>
       <p>
         Peaks.js is a JavaScript library that allows you to display and
@@ -82,43 +84,49 @@
         This demo shows how configure Peaks.js to render a single zoomable
         waveform view.
       </p>
-    </div>
 
-    <div id="waveform-container">
-      <div id="zoomview-container"></div>
-    </div>
+      <div id="waveform-container">
+        <div id="zoomview-container"></div>
+      </div>
 
-    <div id="demo-controls">
-      <audio id="audio" controls="controls">
-        <source src="TOL_6min_720p_download.mp3" type="audio/mpeg">
-        <source src="TOL_6min_720p_download.ogg" type="audio/ogg">
-        Your browser does not support the audio element.
-      </audio>
+      <div id="demo-controls">
+        <audio id="audio" controls="controls">
+          <source src="TOL_6min_720p_download.mp3" type="audio/mpeg">
+          <source src="TOL_6min_720p_download.ogg" type="audio/ogg">
+          Your browser does not support the audio element.
+        </audio>
 
-      <div id="controls">
-        <button data-action="zoom-in">Zoom in</button>
-        <button data-action="zoom-out">Zoom out</button>
-        <input type="text" id="seek-time" value="0.0">
-        <button data-action="seek">Seek</button>
-        <label for="amplitude-scale">Amplitude scale</label>
-        <input type="range" id="amplitude-scale" min="0" max="10" step="1">
-        <label for="waveform-color">Waveform color</label>
-        <input type="color" id="waveform-color" value="#00e180">
+        <div id="controls">
+          <label for="zoom">Zoom:</label>
+          <select id="zoom"></select>
+          <input type="text" id="seek-time" value="0.0">
+          <button data-action="seek">Seek</button>
+          <label for="amplitude-scale">Amplitude scale</label>
+          <input type="range" id="amplitude-scale" min="0" max="10" step="1">
+          <label for="waveform-color">Waveform color</label>
+          <input type="color" id="waveform-color" value="#00e180">
+        </div>
       </div>
     </div>
-
+    <div id="margin-right">
+    </div>
     <script src="peaks.js"></script>
     <script>
       (function(Peaks) {
+        var AudioContext = window.AudioContext || window.webkitAudioContext;
+        var audioContext = new AudioContext();
+
         var options = {
           containers: {
             zoomview: document.getElementById('zoomview-container')
           },
           mediaElement: document.getElementById('audio'),
-          dataUri: {
-            arraybuffer: 'TOL_6min_720p_download.dat',
-            json: 'TOL_6min_720p_download.json'
+          webAudio: {
+            audioContext: audioContext,
+            scale: 128,
+            multiChannel: false
           },
+          zoomLevels: [128],
           keyboard: true,
           pointMarkerColor: '#006eb0',
           zoomWaveformColor: '#00e180',
@@ -128,12 +136,23 @@
         Peaks.init(options, function(err, peaksInstance) {
           console.log('Peaks instance ready');
 
-          document.querySelector('[data-action="zoom-in"]').addEventListener('click', function() {
-            peaksInstance.zoom.zoomIn();
-          });
+          var zoomview = peaksInstance.views.getView('zoomview');
 
-          document.querySelector('[data-action="zoom-out"]').addEventListener('click', function() {
-            peaksInstance.zoom.zoomOut();
+          var zoomLevels = [5, 10, 20, 30, 60, 120, 180, 'auto'];
+
+          zoomview.setZoomLevel({ seconds: zoomLevels[0] });
+
+          var zoom = document.getElementById('zoom');
+
+          for (var i = 0; i < zoomLevels.length; i++) {
+            var text = zoomLevels[i] === 'auto' ? 'Fit width' : (zoomLevels[i] + " seconds");
+            zoom.options[i] = new Option(text, i);
+          }
+
+          zoom.addEventListener('change', function(event) {
+            var zoomLevel = zoomLevels[event.target.value];
+
+            zoomview.setZoomLevel({ seconds: zoomLevel });
           });
 
           document.querySelector('button[data-action="seek"]').addEventListener('click', function(event) {

--- a/demo/zoomable-waveform.html
+++ b/demo/zoomable-waveform.html
@@ -140,7 +140,7 @@
 
           var zoomLevels = [5, 10, 20, 30, 60, 120, 180, 'auto'];
 
-          zoomview.setZoomLevel({ seconds: zoomLevels[0] });
+          zoomview.setZoom({ seconds: zoomLevels[0] });
 
           var zoom = document.getElementById('zoom');
 
@@ -152,7 +152,7 @@
           zoom.addEventListener('change', function(event) {
             var zoomLevel = zoomLevels[event.target.value];
 
-            zoomview.setZoomLevel({ seconds: zoomLevel });
+            zoomview.setZoom({ seconds: zoomLevel });
           });
 
           document.querySelector('button[data-action="seek"]').addEventListener('click', function(event) {

--- a/src/main/views/waveform.overview.js
+++ b/src/main/views/waveform.overview.js
@@ -355,21 +355,23 @@ define([
   };
 
   WaveformOverview.prototype.fitToContainer = function() {
+    if (this._container.clientWidth === 0 && this._container.clientHeight === 0) {
+      return;
+    }
+
     var updateWaveform = false;
 
     if (this._container.clientWidth !== this._width) {
       this._width = this._container.clientWidth;
+      this._stage.setWidth(this._width);
 
       try {
         this._data = this._originalWaveformData.resample({ width: this._width });
+        updateWaveform = true;
       }
       catch (error) {
         // Ignore, and leave this._data as it was
       }
-
-      this._stage.setWidth(this._width);
-
-      updateWaveform = true;
     }
 
     this._height = this._container.clientHeight;

--- a/src/main/views/waveform.zoomcontroller.js
+++ b/src/main/views/waveform.zoomcontroller.js
@@ -67,15 +67,15 @@ define([], function() {
       return;
     }
 
-    var previousZoomLevelIndex = this._zoomLevelIndex;
-
     this._zoomLevelIndex = zoomLevelIndex;
 
-    this._peaks.emit(
-      'zoom.update',
-      this._zoomLevels[zoomLevelIndex],
-      this._zoomLevels[previousZoomLevelIndex]
-    );
+    var zoomview = this._peaks.views.getView('zoomview');
+
+    if (!zoomview) {
+      return;
+    }
+
+    zoomview.setZoom({ scale: this._zoomLevels[zoomLevelIndex] });
   };
 
   /**

--- a/src/main/views/waveform.zoomview.js
+++ b/src/main/views/waveform.zoomview.js
@@ -577,15 +577,37 @@ define([
   };
 
   WaveformZoomView.prototype.fitToContainer = function() {
-    this._width = this._container.clientWidth;
-    this._height = this._container.clientHeight;
+    if (this._container.clientWidth === 0 && this._container.clientHeight === 0) {
+      return;
+    }
 
-    this._stage.width(this._width);
+    var updateWaveform = false;
+
+    if (this._container.clientWidth !== this._width) {
+      this._width = this._container.clientWidth;
+      this._stage.width(this._width);
+
+      if (!this._fixedZoom) {
+        try {
+          this._data = this._originalWaveformData.resample({ width: this._width });
+          updateWaveform = true;
+        }
+        catch (error) {
+          // Ignore, and leave this._data as it was
+        }
+      }
+    }
+
+    this._height = this._container.clientHeight;
     this._stage.height(this._height);
 
     this._playheadLayer.fitToView();
     this._segmentsLayer.fitToView();
     this._pointsLayer.fitToView();
+
+    if (updateWaveform) {
+      this._updateWaveform(this._frameOffset);
+    }
 
     this._stage.draw();
   };

--- a/src/main/waveform/waveform.utils.js
+++ b/src/main/waveform/waveform.utils.js
@@ -219,6 +219,10 @@ define(function() {
 
     isHTMLElement: function(value) {
       return value instanceof HTMLElement;
+    },
+
+    objectHasProperty: function(object, field) {
+      return Object.prototype.hasOwnProperty.call(object, field);
     }
   };
 });


### PR DESCRIPTION
This PR adds a `zoomview.setZoom()` API that gives applications greater flexibility in setting the zoom level. The zoom level can be set to (a) a number of samples per pixel, as per the existing `peaks.zoom.setZoom()` API, (b) a number of seconds fit to the available width, or (c) the entire audio duration fit to the available width.

The minimum number of samples per pixel is still determined by the waveform data file (.dat or .json), or when initially generated using Web Audio.

Refer to the `demo/zoomable-waveform.html` example to see how to use this API.

Resolves #210, #225, and #295.