### PR TITLE
setSource mediaUrl optional

### DIFF
--- a/peaks.js.d.ts
+++ b/peaks.js.d.ts
@@ -48,10 +48,7 @@ declare module 'peaks.js' {
     update: (options: PointUpdateOptions) => void;
   }
 
-  interface RequiredOptions {
-    /** HTML5 Media element containing an audio track */
-    mediaElement: Element;
-  }
+  interface RequiredOptions {  }
 
   interface SingleContainerOptions {
     /** Container element for the waveform views */
@@ -158,6 +155,8 @@ declare module 'peaks.js' {
   }
 
   interface OptionalOptions {
+    /** HTML5 Media element containing an audio track. Optional when using an ArrayBuffer */
+    mediaElement?: Element;
     /**
      * If true, peaks will send credentials with all network requests
      * - i.e. when fetching waveform data.

--- a/src/main.js
+++ b/src/main.js
@@ -557,6 +557,13 @@ define([
   Peaks.prototype.setSource = function(options, callback) {
     var self = this;
 
+    if (Utils.objectHasProperty(options, 'mediaElement') &&
+        !Utils.objectHasProperty(options, 'mediaUrl')) {
+      // eslint-disable-next-line max-len
+      callback(new Error('peaks.setSource(): options must contain a mediaUrl when using mediaElement'));
+      return;
+    }
+
     function reset() {
       self.removeAllListeners('player.canplay');
       self.removeAllListeners('player.error');

--- a/src/main.js
+++ b/src/main.js
@@ -557,10 +557,9 @@ define([
   Peaks.prototype.setSource = function(options, callback) {
     var self = this;
 
-    if (Utils.objectHasProperty(options, 'mediaElement') &&
-        !Utils.objectHasProperty(options, 'mediaUrl')) {
+    if ((options.mediaElement || this.options.mediaElement) && !options.mediaUrl) {
       // eslint-disable-next-line max-len
-      callback(new Error('peaks.setSource(): options must contain a mediaUrl when using mediaElement'));
+      callback(new TypeError('peaks.setSource(): options must contain a mediaUrl when using mediaElement'));
       return;
     }
 

--- a/src/main.js
+++ b/src/main.js
@@ -557,11 +557,6 @@ define([
   Peaks.prototype.setSource = function(options, callback) {
     var self = this;
 
-    if (!options.mediaUrl) {
-      callback(new Error('peaks.setSource(): options must contain a mediaUrl'));
-      return;
-    }
-
     function reset() {
       self.removeAllListeners('player.canplay');
       self.removeAllListeners('player.error');
@@ -608,7 +603,12 @@ define([
     self.once('player.canplay', playerCanPlayHandler);
     self.once('player.error', playerErrorHandler);
 
-    self.options.mediaElement.setAttribute('src', options.mediaUrl);
+    if (options.mediaUrl) {
+      self.options.mediaElement.setAttribute('src', options.mediaUrl);
+    }
+    else {
+      playerCanPlayHandler();
+    }
   };
 
   Peaks.prototype.getWaveformData = function() {

--- a/test/unit/api-spec.js
+++ b/test/unit/api-spec.js
@@ -7,6 +7,18 @@ var WaveformData = require('waveform-data');
 
 var TestAudioContext = window.AudioContext || window.mozAudioContext || window.webkitAudioContext;
 
+var externalPlayer = {
+  init: function() {},
+  destroy: function() {},
+  play: function() {},
+  pause: function() {},
+  seek: function() {},
+  isPlaying: function() {},
+  isSeeking: function() {},
+  getCurrentTime: function() {},
+  getDuration: function() {}
+};
+
 describe('Peaks', function() {
   var p = null;
 
@@ -240,6 +252,29 @@ describe('Peaks', function() {
                 done();
               });
             });
+        });
+      });
+
+      context('with external player', function() {
+        it('should ignore mediaUrl if using an external player', function(done) {
+          var sampleJsonData = require('../../test_data/sample.json');
+
+          Peaks.init({
+            containers: {
+              overview: document.getElementById('overview-container'),
+              zoomview: document.getElementById('zoomview-container')
+            },
+            mediaUrl: 'invalid',
+            waveformData: {
+              json: sampleJsonData
+            },
+            player: externalPlayer
+          }, function(err, instance) {
+            expect(err).to.equal(null);
+            expect(instance).to.be.an.instanceOf(Peaks);
+            instance.destroy();
+            done();
+          });
         });
       });
     });
@@ -692,6 +727,22 @@ describe('Peaks', function() {
           expect(error).to.be.undefined;
           expect(p.zoom.getZoomLevel()).to.equal(128);
           expect(waveformLayerDraw.callCount).to.equal(1);
+          done();
+        });
+      });
+    });
+
+    context('with missing mediaUrl', function() {
+      it('should return an error', function(done) {
+        var options = {
+          webAudio: {
+            audioContext: new TestAudioContext()
+          }
+        };
+
+        p.setSource(options, function(error) {
+          expect(error).to.be.an.instanceOf(TypeError);
+          expect(error.message).to.match(/options must contain a mediaUrl/);
           done();
         });
       });


### PR DESCRIPTION
Removed the required for mediaUrl in the setSource method.

If no mediaUrl is present, it will run `playerCanPlayHandler` since no callback is made otherwise.

See #351 