### PR TITLE
Playhead fixed center

### DIFF
--- a/peaks.js.d.ts
+++ b/peaks.js.d.ts
@@ -229,6 +229,8 @@ declare module 'peaks.js' {
     points?: Point[];
     /** Emit cue events when playing */
     emitCueEvents?: boolean;
+    /** Fixes the zoom waveform playhead marker at the center of the container. */
+    playheadFixedCenter?: boolean
     /** Custom segment marker factory function */
     createSegmentMarker?: (options: CreateSegmentMarkerOptions) => SegmentMarker;
     /** Custom segment label factory function */

--- a/src/main.js
+++ b/src/main.js
@@ -258,6 +258,11 @@ define([
       emitCueEvents: false,
 
       /**
+       * Fixes the zoom waveform playhead marker at the center of the container.
+       */
+      playheadFixedCenter: false,
+
+      /**
        * Point/Segment marker customisation.
        *
        * @todo This part of the API is not stable.

--- a/src/main.js
+++ b/src/main.js
@@ -562,6 +562,11 @@ define([
   Peaks.prototype.setSource = function(options, callback) {
     var self = this;
 
+    if (!options.mediaUrl) {
+      callback(new Error('peaks.setSource(): options must contain a mediaUrl'));
+      return;
+    }
+
     function reset() {
       self.removeAllListeners('player.canplay');
       self.removeAllListeners('player.error');
@@ -608,12 +613,7 @@ define([
     self.once('player.canplay', playerCanPlayHandler);
     self.once('player.error', playerErrorHandler);
 
-    if (options.mediaUrl) {
-      self.options.mediaElement.setAttribute('src', options.mediaUrl);
-    }
-    else {
-      playerCanPlayHandler();
-    }
+    self.options.mediaElement.setAttribute('src', options.mediaUrl);
   };
 
   Peaks.prototype.getWaveformData = function() {

--- a/src/main.js
+++ b/src/main.js
@@ -557,11 +557,6 @@ define([
   Peaks.prototype.setSource = function(options, callback) {
     var self = this;
 
-    if (!options.mediaUrl) {
-      callback(new Error('peaks.setSource(): options must contain a mediaUrl'));
-      return;
-    }
-
     function reset() {
       self.removeAllListeners('player.canplay');
       self.removeAllListeners('player.error');
@@ -608,7 +603,12 @@ define([
     self.once('player.canplay', playerCanPlayHandler);
     self.once('player.error', playerErrorHandler);
 
-    self.options.mediaElement.setAttribute('src', options.mediaUrl);
+    if (options.mediaUrl) {
+      self.options.mediaElement.setAttribute('src', options.mediaUrl);
+    }
+    else {
+      playerCanPlayHandler();
+    }
   };
 
   Peaks.prototype.getWaveformData = function() {

--- a/src/playhead-layer.js
+++ b/src/playhead-layer.js
@@ -27,6 +27,7 @@ define([
    * @param {String} options.playheadFontFamily
    * @param {Number} options.playheadFontSize
    * @param {String} options.playheadFontStyle
+   * @param {Boolean} options.playheadFixedCenter
    */
 
   function PlayheadLayer(options) {
@@ -37,6 +38,7 @@ define([
     this._playheadVisible = false;
     this._playheadColor = options.playheadColor;
     this._playheadTextColor = options.playheadTextColor;
+    this._playheadFixedCenter = options.playheadFixedCenter;
 
     this._playheadFontFamily = options.playheadFontFamily || 'sans-serif';
     this._playheadFontSize = options.playheadFontSize || 11;
@@ -181,8 +183,11 @@ define([
     var frameOffset = this._view.getFrameOffset();
     var width = this._view.getWidth();
 
-    var isVisible = (pixelIndex >= frameOffset) &&
-                    (pixelIndex <  frameOffset + width);
+    var isVisible = this._playheadFixedCenter ||
+                    (
+                      (pixelIndex >= frameOffset) &&
+                      (pixelIndex <  frameOffset + width)
+                    );
 
     this._playheadPixel = pixelIndex;
 
@@ -192,6 +197,11 @@ define([
       if (!this._playheadVisible) {
         this._playheadVisible = true;
         this._playheadGroup.show();
+      }
+
+      if (this._playheadFixedCenter) {
+        // TODO: use highlight width instead of view width
+        playheadX = width / 2;
       }
 
       this._playheadGroup.setAttr('x', playheadX);

--- a/src/waveform-overview.js
+++ b/src/waveform-overview.js
@@ -119,7 +119,8 @@ define([
       playheadTextColor: self._options.playheadTextColor,
       playheadFontFamily: self._options.fontFamily,
       playheadFontSize: self._options.fontSize,
-      playheadFontStyle: self._options.fontStyle
+      playheadFontStyle: self._options.fontStyle,
+      playheadFixedCenter: self._options.playheadFixedCenter
     });
 
     self._playheadLayer.addToStage(self._stage);


### PR DESCRIPTION
This is a work in progress, just need some feedback before I can continue.

This PR adds the `playheadFixedCenter` option and keeps the center of the zoom waveform at the center.
I've tested it with the Points API and it works well.
The segments act strange though, they only seem to appear when the center is in the middle of a segment. Can't really figure out why, would like a pointer here if possible.

Another small thing I wasn't able to figure out yet: When a track is at 0 seconds, it should start at the center but now it still starts at the left side of the view. I suppose there needs to be `width / 2` padding on the left of some sort but I don't know how to do that here.

And the last thing is that the current position marker in the overview needs to be adjusted by `highlight width / 2` but I'm not quite sure where to get the highlight width. Is it available somewhere in the HighlightLayer or should I pass that around?

I'll add tests when everything is done.