### PR TITLE
Add VSCode & WebStorm IDE folders to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ docs
 node_modules
 peaks.js
 peaks.js.map
+
+# Editor/IDE config folders
+.vscode
+.idea


### PR DESCRIPTION
Minor change to ignore config folders created by VS Code & WebStorm