### PR TITLE
Fixed player.playing event name in .d.ts file

### DIFF
--- a/peaks.js.d.ts
+++ b/peaks.js.d.ts
@@ -280,7 +280,7 @@ declare module 'peaks.js' {
     'player.canplay': () => void;
     'player.error': (error: any) => void;
     'player.pause': (time: number) => void;
-    'player.play': (time: number) => void;
+    'player.playing': (time: number) => void;
     'player.seeked': (time: number) => void;
     'player.timeupdate': (time: number) => void;
   }


### PR DESCRIPTION
I noticed I was getting TypeScript errors when using this event, and realized it was wrong in the typedef file.