### PR TITLE
Added player.ended event

### DIFF
--- a/README.md
+++ b/README.md
@@ -1146,6 +1146,7 @@ The following sections describe the available events.
 | `player.playing`    | `Number time` |
 | `player.seeked`     | `Number time` |
 | `player.timeupdate` | `Number time` |
+| `player.ended`      | (none)        |
 
 #### Views
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -563,6 +563,10 @@
           peaksInstance.on('player.pause', function(time) {
             console.log('player.pause:', time);
           });
+
+          peaksInstance.on('player.ended', function() {
+            console.log('player.ended');
+          });
         });
       })(peaks);
     </script>

--- a/peaks.js.d.ts
+++ b/peaks.js.d.ts
@@ -278,6 +278,7 @@ declare module 'peaks.js' {
     'zoomview.dblclick': (time: number) => void;
     'zoom.update': (currentZoomLevel: number, previousZoomLevel: number) => void;
     'player.canplay': () => void;
+    'player.ended': () => void;
     'player.error': (error: any) => void;
     'player.pause': (time: number) => void;
     'player.play': (time: number) => void;

--- a/src/mediaelement-player.js
+++ b/src/mediaelement-player.js
@@ -64,6 +64,10 @@ define([
       self._peaks.emit('player.pause', self.getCurrentTime());
     });
 
+    self._addMediaListener('ended', function() {
+      self._peaks.emit('player.ended');
+    });
+
     self._addMediaListener('seeked', function() {
       self._peaks.emit('player.seeked', self.getCurrentTime());
     });

--- a/src/player.js
+++ b/src/player.js
@@ -203,6 +203,7 @@ define([
       }
       else {
         this.pause();
+        this._peaks.emit('player.ended');
         this._playingSegment = false;
         return;
       }


### PR DESCRIPTION
This is emitted when the audio element itself emits an "ended" event, as well as when a segment played by `playSegment()` reaches the endpoint.