### PR TITLE
Update README code example to use correct element ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,8 +255,8 @@ const audioContext = new AudioContext();
 
 const options = {
   containers: {
-    overview: document.getElementById('overview-waveform'),
-    zoomview: document.getElementById('zoomview-waveform')
+    overview: document.getElementById('overview-container'),
+    zoomview: document.getElementById('zoomview-container')
   },
   mediaElement: document.querySelector('audio'),
   webAudio: {
@@ -282,8 +282,8 @@ audioContext.decodeAudioData(arrayBuffer)
   .then(function(audioBuffer) {
     const options = {
       containers: {
-        overview: document.getElementById('overview-waveform'),
-        zoomview: document.getElementById('zoomview-waveform')
+        overview: document.getElementById('overview-container'),
+        zoomview: document.getElementById('zoomview-container')
       },
       mediaElement: document.querySelector('audio'),
       webAudio: {


### PR DESCRIPTION
I copied the code snippet from the README while setting up PeakJS and was confused why I was getting an error. Turns out there are two code examples that incorrectly reference the HTML element IDs as `overview-waveform` and `zoomview-waveform` but they are set up in the very first example as `X-container` instead of `X-waveform`.

This PR updates these two examples to reference `overview-container` and `zoomview-container` to be consistent with all the other examples.