### PR TITLE
Allow null on mediaElement

### DIFF
--- a/peaks.js.d.ts
+++ b/peaks.js.d.ts
@@ -160,7 +160,7 @@ declare module 'peaks.js' {
 
   interface OptionalOptions {
     /** HTML5 Media element containing an audio track. Optional when using an external player */
-    mediaElement?: Element;
+    mediaElement?: Element | null;
     /**
      * If true, peaks will send credentials with all network requests
      * - i.e. when fetching waveform data.


### PR DESCRIPTION
attn: @evanlouie 

The current type definition of `mediaElement` is `Element`, however if you assign `document.querySelector()` or `document.getElementById()` to `mediaElement`, they return `Element | null`. This change adjusts the type definition to account for this and properly allow these selectors.

*Note: I don't know if actually having a `null` value for `mediaElement` would cause other issues :/*