### PR TITLE
Mouse handler updates, add trackpad horizontal scrolling

### DIFF
--- a/peaks.js.d.ts
+++ b/peaks.js.d.ts
@@ -375,6 +375,7 @@ declare module 'peaks.js' {
     };
     /** Events */
     on: <E extends keyof InstanceEvents>(event: E, listener: InstanceEvents[E]) => void;
+    off: <E extends keyof InstanceEvents>(event: E, listener: InstanceEvents[E]) => void;
   }
 
   type PeaksInitCallback = (error: Error, peaks?: PeaksInstance) => void;

--- a/src/mouse-drag-handler.js
+++ b/src/mouse-drag-handler.js
@@ -74,12 +74,15 @@ define([
       return;
     }
 
-    this._lastMouseClientX = Math.floor(
+    var clientX = Math.floor(
       event.type === 'touchstart' ? event.evt.touches[0].clientX : event.evt.clientX
     );
 
+    this._mouseDownClientX = clientX;
+    this._lastMouseClientX = clientX;
+
     if (this._handlers.onMouseDown) {
-      var mouseDownPosX = this._getMousePosX(this._lastMouseClientX);
+      var mouseDownPosX = this._getMousePosX(clientX);
 
       this._handlers.onMouseDown(mouseDownPosX);
     }
@@ -116,7 +119,7 @@ define([
     if (this._handlers.onMouseMove) {
       var mousePosX = this._getMousePosX(clientX);
 
-      this._handlers.onMouseMove(mousePosX);
+      this._handlers.onMouseMove(mousePosX, clientX - this._mouseDownClientX);
     }
   };
 
@@ -143,7 +146,7 @@ define([
     if (this._handlers.onMouseUp) {
       var mousePosX = this._getMousePosX(clientX);
 
-      this._handlers.onMouseUp(mousePosX);
+      this._handlers.onMouseUp(mousePosX, clientX - this._mouseDownClientX);
     }
 
     window.removeEventListener('mousemove', this._mouseMove, false);

--- a/src/mouse-drag-handler.js
+++ b/src/mouse-drag-handler.js
@@ -57,13 +57,13 @@ define([
     this._stage.on('mousedown', this._mouseDown);
     this._stage.on('touchstart', this._mouseDown);
 
-    this._mouseDownClientX = null;
+    this._lastMouseClientX = null;
   }
 
   /**
    * Mouse down event handler.
    *
-   * @param {MouseEvent} event
+   * @param {KonvaEventObject} event
    */
 
   MouseDragHandler.prototype._mouseDown = function(event) {
@@ -74,12 +74,12 @@ define([
       return;
     }
 
-    this._mouseDownClientX = Math.floor(
+    this._lastMouseClientX = Math.floor(
       event.type === 'touchstart' ? event.evt.touches[0].clientX : event.evt.clientX
     );
 
     if (this._handlers.onMouseDown) {
-      var mouseDownPosX = this._getMousePosX(this._mouseDownClientX);
+      var mouseDownPosX = this._getMousePosX(this._lastMouseClientX);
 
       this._handlers.onMouseDown(mouseDownPosX);
     }
@@ -106,9 +106,10 @@ define([
     );
 
     // Don't update on vertical mouse movement.
-    if (clientX === this._mouseDownClientX) {
+    if (clientX === this._lastMouseClientX) {
       return;
     }
+    this._lastMouseClientX = clientX;
 
     this._dragging = true;
 

--- a/src/mouse-drag-handler.js
+++ b/src/mouse-drag-handler.js
@@ -53,9 +53,11 @@ define([
     this._mouseDown = this._mouseDown.bind(this);
     this._mouseUp   = this._mouseUp.bind(this);
     this._mouseMove = this._mouseMove.bind(this);
+    this._mouseWheel = this._mouseWheel.bind(this);
 
     this._stage.on('mousedown', this._mouseDown);
     this._stage.on('touchstart', this._mouseDown);
+    this._stage.on('wheel', this._mouseWheel);
 
     this._lastMouseClientX = null;
   }
@@ -156,6 +158,28 @@ define([
     window.removeEventListener('blur', this._mouseUp, false);
 
     this._dragging = false;
+  };
+
+  /**
+   * Mouse wheel event handler.
+   *
+   * @param {KonvaEventObject} event
+   */
+
+  MouseDragHandler.prototype._mouseWheel = function(eventObject) {
+    var event = eventObject.evt;
+    var delta = event.shiftKey ? event.deltaY : event.deltaX;
+    var offAxisDelta = event.shiftKey ? event.deltaX : event.deltaY;
+
+    // Ignore the event if it looks like the user is scrolling vertically down the page
+    if (Math.abs(delta) < Math.abs(offAxisDelta)) {
+      return;
+    }
+
+    if (delta && this._handlers.onMouseWheel) {
+      this._handlers.onMouseWheel(delta);
+      event.preventDefault();
+    }
   };
 
   /**

--- a/src/waveform-zoomview.js
+++ b/src/waveform-zoomview.js
@@ -156,6 +156,10 @@ define([
 
           self._peaks.player.seek(time);
         }
+      },
+
+      onMouseWheel: function(deltaX) {
+        self.scrollWaveform(deltaX);
       }
     });
 

--- a/src/waveform-zoomview.js
+++ b/src/waveform-zoomview.js
@@ -136,13 +136,7 @@ define([
         // left-hand edge of the visible waveform.
         var diff = -offset;
 
-        var newFrameOffset = Utils.clamp(
-          this.initialFrameOffset + diff, 0, self._pixelLength - self._width
-        );
-
-        if (newFrameOffset !== this.initialFrameOffset) {
-          self._updateWaveform(newFrameOffset);
-        }
+        self._updateWaveform(this.initialFrameOffset + diff);
       },
 
       onMouseUp: function(mousePosX) {

--- a/src/waveform-zoomview.js
+++ b/src/waveform-zoomview.js
@@ -126,15 +126,15 @@ define([
     self._syncPlayhead(time);
 
     self._mouseDragHandler = new MouseDragHandler(self._stage, {
-      onMouseDown: function(mousePosX) {
+      onMouseDown: function(/* mousePosX */) {
         this.initialFrameOffset = self._frameOffset;
-        this.mouseDownX = mousePosX;
       },
 
-      onMouseMove: function(mousePosX) {
+      // eslint-disable-next-line no-unused-vars
+      onMouseMove: function(mousePosX, offset) {
         // Moving the mouse to the left increases the time position of the
         // left-hand edge of the visible waveform.
-        var diff = this.mouseDownX - mousePosX;
+        var diff = -offset;
 
         var newFrameOffset = Utils.clamp(
           this.initialFrameOffset + diff, 0, self._pixelLength - self._width
@@ -145,13 +145,10 @@ define([
         }
       },
 
-      onMouseUp: function(/* mousePosX */) {
+      onMouseUp: function(mousePosX) {
         // Set playhead position only on click release, when not dragging.
         if (!self._mouseDragHandler.isDragging()) {
-          var mouseDownX = Math.floor(this.mouseDownX);
-
-          var pixelIndex = self._frameOffset + mouseDownX;
-
+          var pixelIndex = self._frameOffset + Math.floor(mousePosX);
           var time = self.pixelsToTime(pixelIndex);
           var duration = self._getDuration();
 

--- a/src/waveform-zoomview.js
+++ b/src/waveform-zoomview.js
@@ -248,7 +248,7 @@ define([
       increment = direction * this.timeToPixels(this._options.nudgeIncrement);
     }
 
-    this._updateWaveform(this._frameOffset + increment);
+    this.scrollWaveform(increment);
   };
 
   WaveformZoomView.prototype.setWaveformData = function(waveformData) {
@@ -525,6 +525,16 @@ define([
 
     this._axis.addToLayer(this._axisLayer);
     this._stage.add(this._axisLayer);
+  };
+
+  /**
+   * Scrolls the region of waveform shown in the view.
+   *
+   * @param {Number} scrollAmount How far to scroll, in pixels
+   */
+
+  WaveformZoomView.prototype.scrollWaveform = function(scrollAmount) {
+    this._updateWaveform(this._frameOffset + scrollAmount);
   };
 
   /**


### PR DESCRIPTION
The main feature I wanted to add here was responding to mousewheel events, so that doing a horizontal swipe on the zoomview waveform scrolls it. It feels pretty nice on an Apple Mouse & trackpad, but would welcome any feedback how well it works on a conventional clicky scrollwheel if anyone has one.

There's also a grabbag of minor fixes & cleanup around MouseDragHandler (which would skip a drag event if you dragged back over the position you started at), and it exposes a public zoomview.scrollWaveform method to allow scrolling from an external control.

I put the mousewheel listener in MouseDragHandler because it fits pretty cleanly in there, but concede it's not actually a _drag_ as such. Happy for other suggestions...