### PR TITLE
Add root:true to eslintrc.js

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,5 @@
 module.exports = {
+  'root': true,
   'env': {
     'browser': true,
     'amd': true


### PR DESCRIPTION
Before this, when using peaks in a subdirectory of a larger project, peak's linting rules would combine with the parent project linting rules, which doesn't seem desirable.