### PR TITLE
Fix overviewHighlightColor, update .d.ts

### DIFF
--- a/peaks.js.d.ts
+++ b/peaks.js.d.ts
@@ -62,7 +62,30 @@ declare module 'peaks.js' {
     }
   }
 
-  type ContainerOptions = SingleContainerOptions | ViewContainerOptions;
+  interface SharedViewOptions {
+    axisGridlineColor?: string;
+    axisLabelColor?: string;
+    container?: HTMLElement | null;
+    fontFamily?: string;
+    fontSize?: number;
+    fontStyle?: string;
+    playedWaveformColor?: string;
+    playheadColor?: string;
+    playheadTextColor?: string;
+    timeLabelPrecision?: number;
+    waveformColor?: string;
+  }
+  interface SeparateViewOptions {
+    zoomview?: SharedViewOptions & {
+      wheelMode?: "none" | "scroll";
+    };
+    overview?: SharedViewOptions & {
+      highlightColor?: string;
+      highlightOffset?: number;
+    };
+  }
+
+  type ContainerOptions = SingleContainerOptions | ViewContainerOptions | SeparateViewOptions;
 
   interface PreGeneratedWaveformOptions {
     /** URI to waveform data file in binary or JSON */

--- a/peaks.js.d.ts
+++ b/peaks.js.d.ts
@@ -344,9 +344,13 @@ declare module 'peaks.js' {
     enableAutoScroll: (enable: boolean) => void;
     enableMarkerEditing: (enable: boolean) => void;
     fitToContainer: () => void;
-    setZoom: (options: XOR<{ scale: number | 'auto' }, { seconds: number | 'auto' }>) => void;
+  }
+  interface WaveformOverView extends WaveformView {}
+  interface WaveformZoomView extends WaveformView {
+    scrollWaveform: (offset: number) => void;
     setStartTime: (time: number) => void;
     setWheelMode: (mode: 'scroll' | 'none') => void;
+    setZoom: (options: XOR<{ scale: number | 'auto' }, { seconds: number | 'auto' }>) => void;
   }
 
   type Without<T> = { [K in keyof T]?: undefined };
@@ -366,11 +370,13 @@ declare module 'peaks.js' {
     };
     /** Views API */
     views: {
-      createOverview: (container: HTMLElement) => WaveformView;
-      createZoomview: (container: HTMLElement) => WaveformView;
+      createOverview: (container: HTMLElement) => WaveformOverView;
+      createZoomview: (container: HTMLElement) => WaveformZoomView;
       destroyOverview: () => void;
       destroyZoomview: () => void;
-      getView: (name?: 'overview' | 'zoomview') => WaveformView | null;
+      getView(name?: null): WaveformView | null;
+      getView(name: 'overview'): WaveformOverView | null;
+      getView(name: 'zoomview'): WaveformZoomView | null;
     };
     /** Zoom API */
     zoom: {

--- a/src/main.js
+++ b/src/main.js
@@ -139,7 +139,9 @@ define([
       'axisLabelColor',
       'fontFamily',
       'fontSize',
-      'fontStyle'
+      'fontStyle',
+      'highlightColor',
+      'highlightOffset'
     ];
 
     optNames.forEach(function(optName) {


### PR DESCRIPTION
overviewHighlightColor stopped working in https://github.com/bbc/peaks.js/commit/93c7024ccfccfbfa13de2addac644492fb2219cf - this fixes that and updates the types to cover the new options structure.

(Update: actually, overviewHighlightColor continued working as long as you specified both it and the overviewHighlightOffset. But it was no longer applying the default values for either, and they couldn't be specified via the new 'options.overview' option.)