### PR TITLE
Fix JS typo and add details in installation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,7 +403,7 @@ var options = {
   randomizeSegmentColor: true,
 
   // Font family for axis labels, playhead, and point and segment markers
-  fontFamily: 'sans-serif'
+  fontFamily: 'sans-serif',
 
   // Font size for axis labels, playhead, and point and segment markers
   fontSize: 11,

--- a/README.md
+++ b/README.md
@@ -129,7 +129,11 @@ and then open your browser at http://localhost:8080.
 
 Peaks.js can be included in any web page by following these steps:
 
-1. include it your web page
+1. Include the following HTML in your web page
+2. Include a media element and its [waveform data file](https://github.com/bbc/audiowaveform)
+3. Install [Peaks.js](#installation)
+4. Initialise Peaks.js with [`Peaks.init()`](#initialization) and your own options
+
 ```html
 <div id="peaks-container">
   <div id="zoomview-container"></div>
@@ -142,13 +146,9 @@ Peaks.js can be included in any web page by following these steps:
 <!-- Using RequireJS -->
 <script src="bower_components/requirejs/require.js" data-main="app.js"></script>
 ```
-1. include a media element and its [waveform data file](https://github.com/bbc/audiowaveform)
-1. install [Peaks.js](#installation)
-1. initialise Peaks.js with `Peaks.init()` and your own options
 
-
-_Note that the container `div`s should be left empty, as shown above, as their
-content will be replaced by the waveform view `canvas` elements._
+Note that the container `div`s should be left empty, as shown above, as their
+content will be replaced by the waveform view `canvas` elements.
 
 ## Start using AMD and [require.js](http://requirejs.org/)
 

--- a/README.md
+++ b/README.md
@@ -695,7 +695,7 @@ The initial setting is `false` for the overview waveform view, or controlled by 
 
 ```js
 const view = instance.views.getView('zoomview');
-view.showPlayeadTime(false); // Remove the time from the playhead marker.
+view.showPlayheadTime(false); // Remove the time from the playhead marker.
 ```
 
 ### `view.setTimeLabelPrecision(precision)`

--- a/README.md
+++ b/README.md
@@ -130,9 +130,6 @@ and then open your browser at http://localhost:8080.
 Peaks.js can be included in any web page by following these steps:
 
 1. include it your web page
-1. include a media element and its [waveform data file](https://github.com/bbc/audiowaveform)
-1. initialise Peaks.js
-
 ```html
 <div id="peaks-container">
   <div id="zoomview-container"></div>
@@ -142,11 +139,16 @@ Peaks.js can be included in any web page by following these steps:
   <source src="test_data/sample.mp3" type="audio/mpeg">
   <source src="test_data/sample.ogg" type="audio/ogg">
 </audio>
+<!-- Using RequireJS -->
 <script src="bower_components/requirejs/require.js" data-main="app.js"></script>
 ```
+1. include a media element and its [waveform data file](https://github.com/bbc/audiowaveform)
+1. install [Peaks.js](#installation)
+1. initialise Peaks.js with `Peaks.init()` and your own options
 
-Note that the container `div`s should be left empty, as shown above, as their
-content will be replaced by the waveform view `canvas` elements.
+
+_Note that the container `div`s should be left empty, as shown above, as their
+content will be replaced by the waveform view `canvas` elements._
 
 ## Start using AMD and [require.js](http://requirejs.org/)
 

--- a/README.md
+++ b/README.md
@@ -172,7 +172,9 @@ require(['peaks'], function(Peaks) {
       zoomview: document.getElementById('zoomview-container')
     }
     mediaElement: document.querySelector('audio'),
-    dataUri: 'test_data/sample.json'
+    dataUri: {
+      json: 'test_data/sample.json',
+    }
   };
 
   Peaks.init(options, function(err, peaks) {


### PR DESCRIPTION
After using Peaks.js, I find 3 "errors" in JS snippets and I found the "Using Peaks.js in your own project" section not really clear for a beginner.

This PR is only about the README file:
- 3 typos in Javascript snippets
- Add one step in the user guide ("Using Peaks.js in your own project" section)
- Refactor the "Using Peaks.js in your own project" section