### PR TITLE
Reduce frame offset wrangling

### DIFF
--- a/peaks.js.d.ts
+++ b/peaks.js.d.ts
@@ -385,7 +385,8 @@ declare module 'peaks.js' {
     };
     /** Segments API */
     segments: {
-      add: (segments: SegmentAddOptions | SegmentAddOptions[]) => void;
+      add(segment: SegmentAddOptions): Segment;
+      add(segments: SegmentAddOptions[]): Segment[];
       getSegments: () => Segment[];
       getSegment: (id: string) => Segment | null;
       removeByTime: (startTime: number, endTime?: number) => Segment[];
@@ -394,7 +395,8 @@ declare module 'peaks.js' {
     };
     /** Points API */
     points: {
-      add: (points: PointAddOptions | PointAddOptions[]) => void;
+      add(point: PointAddOptions): Point;
+      add(points: PointAddOptions[]): Point[];
       getPoints: () => Point[];
       getPoint: (id: string) => Point | null;
       removeByTime: (time: number) => Point[];

--- a/peaks.js.d.ts
+++ b/peaks.js.d.ts
@@ -368,7 +368,7 @@ declare module 'peaks.js' {
     };
     /** Views API */
     views: {
-      createOverview: (container: HTMLElement) => WaveformOverView;
+      createOverview: (container: HTMLElement) => WaveformOverview;
       createZoomview: (container: HTMLElement) => WaveformZoomView;
       destroyOverview: () => void;
       destroyZoomview: () => void;

--- a/src/points-layer.js
+++ b/src/points-layer.js
@@ -83,11 +83,8 @@ define([
   };
 
   PointsLayer.prototype._onPointsUpdate = function(point) {
-    var frameOffset = this._view.getFrameOffset();
-    var width = this._view.getWidth();
-
-    var frameStartTime = this._view.pixelsToTime(frameOffset);
-    var frameEndTime   = this._view.pixelsToTime(frameOffset + width);
+    var frameStartTime = this._view.getStartTime();
+    var frameEndTime   = this._view.getEndTime();
 
     this._removePoint(point);
 
@@ -101,11 +98,8 @@ define([
   PointsLayer.prototype._onPointsAdd = function(points) {
     var self = this;
 
-    var frameOffset = self._view.getFrameOffset();
-    var width = self._view.getWidth();
-
-    var frameStartTime = self._view.pixelsToTime(frameOffset);
-    var frameEndTime   = self._view.pixelsToTime(frameOffset + width);
+    var frameStartTime = self._view.getStartTime();
+    var frameEndTime   = self._view.getEndTime();
 
     points.forEach(function(point) {
       if (point.isVisible(frameStartTime, frameEndTime)) {
@@ -206,11 +200,9 @@ define([
     var markerX = pointMarker.getX();
 
     if (markerX >= 0 && markerX < this._view.getWidth()) {
-      var offset = this._view.getFrameOffset() +
-                   markerX +
-                   pointMarker.getWidth();
+      var offset = markerX + pointMarker.getWidth();
 
-      point._setTime(this._view.pixelsToTime(offset));
+      point._setTime(this._view.pixelOffsetToTime(offset));
 
       pointMarker.timeUpdated(point.time);
     }

--- a/src/segment-shape.js
+++ b/src/segment-shape.js
@@ -220,7 +220,6 @@ define([
    */
 
   SegmentShape.prototype._onSegmentHandleDrag = function(segmentMarker) {
-    var frameOffset = this._view.getFrameOffset();
     var width = this._view.getWidth();
 
     var startMarker = segmentMarker.isStartMarker();
@@ -229,19 +228,18 @@ define([
     var endMarkerX = this._endMarker.getX();
 
     if (startMarker && startMarkerX >= 0) {
-      var startMarkerOffset = frameOffset +
-                              startMarkerX +
+      var startMarkerOffset = startMarkerX +
                               this._startMarker.getWidth();
 
-      this._segment._setStartTime(this._view.pixelsToTime(startMarkerOffset));
+      this._segment._setStartTime(this._view.pixelOffsetToTime(startMarkerOffset));
 
       segmentMarker.timeUpdated(this._segment.startTime);
     }
 
     if (!startMarker && endMarkerX < width) {
-      var endMarkerOffset = frameOffset + endMarkerX;
+      var endMarkerOffset = endMarkerX;
 
-      this._segment._setEndTime(this._view.pixelsToTime(endMarkerOffset));
+      this._segment._setEndTime(this._view.pixelOffsetToTime(endMarkerOffset));
 
       segmentMarker.timeUpdated(this._segment.endTime);
     }

--- a/src/segments-layer.js
+++ b/src/segments-layer.js
@@ -73,10 +73,8 @@ define([
   SegmentsLayer.prototype._onSegmentsUpdate = function(segment) {
     var redraw = false;
     var segmentShape = this._segmentShapes[segment.id];
-    var frameOffset = this._view.getFrameOffset();
-    var width = this._view.getWidth();
-    var frameStartTime = this._view.pixelsToTime(frameOffset);
-    var frameEndTime   = this._view.pixelsToTime(frameOffset + width);
+    var frameStartTime = this._view.getStartTime();
+    var frameEndTime   = this._view.getEndTime();
 
     if (segmentShape) {
       this._removeSegment(segment);
@@ -96,11 +94,8 @@ define([
   SegmentsLayer.prototype._onSegmentsAdd = function(segments) {
     var self = this;
 
-    var frameOffset = self._view.getFrameOffset();
-    var width = self._view.getWidth();
-
-    var frameStartTime = self._view.pixelsToTime(frameOffset);
-    var frameEndTime   = self._view.pixelsToTime(frameOffset + width);
+    var frameStartTime = self._view.getStartTime();
+    var frameEndTime   = self._view.getEndTime();
 
     segments.forEach(function(segment) {
       if (segment.isVisible(frameStartTime, frameEndTime)) {

--- a/src/waveform-axis.js
+++ b/src/waveform-axis.js
@@ -111,7 +111,7 @@ define([
    */
 
   WaveformAxis.prototype.drawAxis = function(context, view) {
-    var currentFrameStartTime = view.pixelsToTime(view.getFrameOffset());
+    var currentFrameStartTime = view.getStartTime();
 
     // Draw axis markers
     var markerHeight = 10;

--- a/src/waveform-overview.js
+++ b/src/waveform-overview.js
@@ -281,12 +281,38 @@ define([
   };
 
   /**
+   * Returns the time for a given pixel index, for the current zoom level.
+   * (This is presented for symmetry with WaveformZoomview. Since WaveformOverview
+   * doesn't scroll, its pixelOffsetToTime & pixelsToTime methods are identical.)
+   *
+   * @param {Number} pixels Pixel index.
+   * @returns {Number} Time, in seconds.
+   */
+  WaveformOverview.prototype.pixelOffsetToTime = WaveformOverview.prototype.pixelsToTime;
+
+  /**
    * @returns {Number} The start position of the waveform shown in the view,
    *   in pixels.
    */
 
   WaveformOverview.prototype.getFrameOffset = function() {
     return 0;
+  };
+
+  /**
+   * @returns {Number} The time at the leftmost edge
+   */
+
+  WaveformOverview.prototype.getStartTime = function() {
+    return 0;
+  };
+
+  /**
+   * @returns {Number} The time at the rightmost edge
+   */
+
+  WaveformOverview.prototype.getEndTime = function() {
+    return this._getDuration();
   };
 
   /**

--- a/src/waveform-points.js
+++ b/src/waveform-points.js
@@ -138,12 +138,15 @@ define([
    * Adds one or more points to the timeline.
    *
    * @param {PointOptions|Array<PointOptions>} pointOrPoints
+   *
+   * @returns Point|Array<Point>
    */
 
   WaveformPoints.prototype.add = function(/* pointOrPoints */) {
     var self = this;
 
-    var points = Array.isArray(arguments[0]) ?
+    var arrayArgs = Array.isArray(arguments[0]);
+    var points = arrayArgs ?
                  arguments[0] :
                  Array.prototype.slice.call(arguments);
 
@@ -162,6 +165,8 @@ define([
     });
 
     this._peaks.emit('points.add', points);
+
+    return arrayArgs ? points : points[0];
   };
 
   /**

--- a/src/waveform-segments.js
+++ b/src/waveform-segments.js
@@ -197,12 +197,14 @@ define([
    * Adds one or more segments to the timeline.
    *
    * @param {SegmentOptions|Array<SegmentOptions>} segmentOrSegments
+   *
+   * @returns Segment|Array<Segment>
    */
 
   WaveformSegments.prototype.add = function(/* segmentOrSegments */) {
     var self = this;
-
-    var segments = Array.isArray(arguments[0]) ?
+    var arrayArgs = Array.isArray(arguments[0]);
+    var segments = arrayArgs ?
                    arguments[0] :
                    Array.prototype.slice.call(arguments);
 
@@ -221,6 +223,8 @@ define([
     });
 
     this._peaks.emit('segments.add', segments);
+
+    return arrayArgs ? segments : segments[0];
   };
 
   /**

--- a/src/waveform-zoomview.js
+++ b/src/waveform-zoomview.js
@@ -139,10 +139,7 @@ define([
         // Moving the mouse to the left increases the time position of the
         // left-hand edge of the visible waveform.
         var diff = this.mouseDownX - mousePosX;
-
-        var newFrameOffset = Utils.clamp(
-          this.initialFrameOffset + diff, 0, self._pixelLength - self._width
-        );
+        var newFrameOffset = this.initialFrameOffset + diff;
 
         self._updateWaveform(newFrameOffset);
       },

--- a/src/waveform-zoomview.js
+++ b/src/waveform-zoomview.js
@@ -302,7 +302,7 @@ define([
       increment = direction * this.timeToPixels(this._options.nudgeIncrement);
     }
 
-    this._updateWaveform(this._frameOffset + increment);
+    this.scrollWaveform(increment);
   };
 
   WaveformZoomView.prototype.setWaveformData = function(waveformData) {
@@ -643,6 +643,16 @@ define([
 
     this._axis.addToLayer(this._axisLayer);
     this._stage.add(this._axisLayer);
+  };
+
+  /**
+   * Scrolls the region of waveform shown in the view.
+   *
+   * @param {Number} scrollAmount How far to scroll, in pixels
+   */
+
+  WaveformZoomView.prototype.scrollWaveform = function(scrollAmount) {
+    this._updateWaveform(this._frameOffset + scrollAmount);
   };
 
   /**

--- a/test/unit/api-points-spec.js
+++ b/test/unit/api-points-spec.js
@@ -174,10 +174,20 @@ describe('Peaks.points', function() {
       ]);
     });
 
-    it('should return undefined', function() {
+    it('should return the new point', function() {
       var result = p.points.add({ time: 0 });
 
-      expect(result).to.be.undefined;
+      expect(result).to.be.an.instanceOf(Point);
+      expect(result.time).to.equal(0);
+      expect(result.id).to.be.a('string');
+    });
+
+    it('should return multiple points when passing an array', function() {
+      var result = p.points.add([{ time: 0 }, { time: 10 }]);
+
+      expect(result).to.be.an.instanceOf(Array);
+      expect(result[0].time).to.equal(0);
+      expect(result[1].time).to.equal(10);
     });
 
     it('should throw an exception if the time is undefined', function() {

--- a/test/unit/api-segments-spec.js
+++ b/test/unit/api-segments-spec.js
@@ -203,10 +203,24 @@ describe('Peaks.segments', function() {
       ]);
     });
 
-    it('should return undefined', function() {
+    it('should return the new segment', function() {
       var result = p.segments.add({ startTime: 0, endTime: 10 });
 
-      expect(result).to.be.undefined;
+      expect(result).to.be.an.instanceOf(Segment);
+      expect(result.startTime).to.equal(0);
+      expect(result.endTime).to.equal(10);
+      expect(result.id).to.be.a('string');
+    });
+
+    it('should return multiple segments when passing an array', function() {
+      var result = p.segments.add([
+        { startTime: 0, endTime: 10 },
+        { startTime: 30, endTime: 40 }
+      ]);
+
+      expect(result).to.be.an.instanceOf(Array);
+      expect(result[0].startTime).to.equal(0);
+      expect(result[1].startTime).to.equal(30);
     });
 
     it('should throw an exception if arguments do not match any previous accepted signature form', function() {


### PR DESCRIPTION
This is a bit of a grab-bag of commits broken out from my segment-dragging branch, which I think are useful whether or not we decide to merge segment-dragging.  I can break them out into separate PRs if you'd prefer - each commit is relatively independent so it might make more sense to review that way.

Do you consider methods like WaveformZoomview.prototype.pixelsToTime to be public? They have jsdoc comments and don't have a "_" prefix, but conversely they aren't in the main documentation or in the Typescript defs. If they're public I'll add them to peaks.d.ts, but I didn't want to add to the public API surface area more than necessary.

I also wanted to check about the removal of some `Math.floor`s - eg here: 

```diff
--- a/src/waveform-zoomview.js
+++ b/src/waveform-zoomview.js
@@ -150,11 +150,7 @@ define([
       onMouseUp: function(/* mousePosX */) {
         // Set playhead position only on click release, when not dragging.
         if (!self._mouseDragHandler.isDragging()) {
-          var mouseDownX = Math.floor(this.mouseDownX);
-
-          var pixelIndex = self._frameOffset + mouseDownX;
-
-          var time = self.pixelsToTime(pixelIndex);
+          var time = self.pixelOffsetToTime(this.mouseDownX);
           var duration = self._getDuration();

           // Prevent the playhead position from jumping by limiting click
```

pixelsToTime & pixelOffsetToTime are both going to multiply their argument by a floating point scale value so I couldn't see a good reason for trying to `floor` the original value to an integer. Let me know if there's something I'm missing, though.