### PR TITLE
Add logger to options

### DIFF
--- a/demo/zoomable-waveform.html
+++ b/demo/zoomable-waveform.html
@@ -139,7 +139,8 @@
             multiChannel: false
           },
           zoomLevels: [128],
-          keyboard: true
+          keyboard: true,
+          logger: console.error.bind(console)
         };
 
         Peaks.init(options, function(err, peaksInstance) {

--- a/demo/zoomable-waveform.html
+++ b/demo/zoomable-waveform.html
@@ -139,8 +139,7 @@
             multiChannel: false
           },
           zoomLevels: [128],
-          keyboard: true,
-          logger: console.error.bind(console)
+          keyboard: true
         };
 
         Peaks.init(options, function(err, peaksInstance) {

--- a/src/main.js
+++ b/src/main.js
@@ -374,9 +374,7 @@ Peaks.prototype._setOptions = function(opts) {
     }
   }
 
-  if (opts.logger) {
-    this.logger = opts.logger;
-  }
+  this._logger = this.options.logger;
 };
 
 /**

--- a/src/player.js
+++ b/src/player.js
@@ -144,7 +144,7 @@ Player.prototype.getDuration = function() {
 
 Player.prototype.seek = function(time) {
   if (!isValidTime(time)) {
-    this._peaks.logger('peaks.player.seek(): parameter must be a valid time, in seconds');
+    this._peaks._logger('peaks.player.seek(): parameter must be a valid time, in seconds');
     return;
   }
 

--- a/src/waveform-builder.js
+++ b/src/waveform-builder.js
@@ -95,7 +95,7 @@ WaveformBuilder.prototype.init = function(options, callback) {
 
   if (options.audioContext) {
     // eslint-disable-next-line max-len
-    this._peaks.logger('Peaks.init(): The audioContext option is deprecated, please pass a webAudio object instead');
+    this._peaks._logger('Peaks.init(): The audioContext option is deprecated, please pass a webAudio object instead');
 
     options.webAudio = {
       audioContext: options.audioContext
@@ -357,7 +357,7 @@ WaveformBuilder.prototype._requestAudioAndBuildWaveformData = function(url,
   var self = this;
 
   if (!url) {
-    self._peaks.logger('Peaks.init(): The mediaElement src is invalid');
+    self._peaks._logger('Peaks.init(): The mediaElement src is invalid');
     return;
   }
 

--- a/src/waveform-zoomview.js
+++ b/src/waveform-zoomview.js
@@ -404,7 +404,7 @@ WaveformZoomView.prototype.setZoom = function(options) {
 
   if (scale < this._originalWaveformData.scale) {
     // eslint-disable-next-line max-len
-    this._peaks.logger('peaks.zoomview.setZoom(): zoom level must be at least ' + this._originalWaveformData.scale);
+    this._peaks._logger('peaks.zoomview.setZoom(): zoom level must be at least ' + this._originalWaveformData.scale);
     scale = this._originalWaveformData.scale;
   }
 

--- a/test/unit/api-player-spec.js
+++ b/test/unit/api-player-spec.js
@@ -5,8 +5,11 @@ describe('Player', function() {
   context('with stub player', function() {
     var p;
     var player;
+    var logger;
 
     beforeEach(function(done) {
+      logger = sinon.spy();
+
       player = {
         init: sinon.spy(),
         destroy: sinon.spy(),
@@ -28,7 +31,7 @@ describe('Player', function() {
         dataUri: {
           json: 'base/test_data/sample.json'
         },
-        logger: sinon.spy(),
+        logger: logger,
         player: player
       };
 
@@ -146,7 +149,7 @@ describe('Player', function() {
       it("should call the player's seek() method", function() {
         p.player.seek(42);
 
-        expect(p.logger.notCalled);
+        expect(logger.notCalled);
         expect(player.seek.calledOnce);
         expect(player.seek).to.have.been.calledWith(42);
       });
@@ -154,7 +157,7 @@ describe('Player', function() {
       it('should log an error if the given time is not valid', function() {
         p.player.seek('6.0');
 
-        expect(p.logger.calledOnce);
+        expect(logger.calledOnce);
         expect(p.player.seek.notCalled);
       });
     });
@@ -163,7 +166,7 @@ describe('Player', function() {
       it('should log an error if a segment id is given', function() {
         p.player.playSegment('peaks.segment.0');
 
-        expect(p.logger.calledOnce);
+        expect(logger.calledOnce);
       });
 
       it("should call the player's seek(), play() and pause() method", function() {
@@ -171,7 +174,7 @@ describe('Player', function() {
 
         p.player.playSegment(segment);
 
-        expect(p.logger.notCalled);
+        expect(logger.notCalled);
 
         expect(player.seek.calledOnce);
         expect(player.seek).to.have.been.calledWith(segment.startTime);
@@ -190,8 +193,11 @@ describe('Player', function() {
 
   context('with media element player', function() {
     var p;
+    var logger;
 
     beforeEach(function(done) {
+      logger = sinon.spy();
+
       var options = {
         containers: {
           overview: document.getElementById('overview-container'),
@@ -273,7 +279,7 @@ describe('Player', function() {
       it('should log an error if the given time is not valid', function() {
         p.player.seek('6.0');
 
-        expect(p.logger.calledOnce);
+        expect(logger.calledOnce);
         expect(p.player.getCurrentTime()).to.equal(0.0);
       });
     });
@@ -282,7 +288,7 @@ describe('Player', function() {
       it('should log an error if a segment id is given', function() {
         p.player.playSegment('peaks.segment.0');
 
-        expect(p.logger.calledOnce);
+        expect(logger.calledOnce);
       });
 
       it('should play a given segment', function() {
@@ -294,7 +300,7 @@ describe('Player', function() {
         p.player.playSegment(segments[0]);
         p.player.pause();
 
-        expect(p.logger.notCalled);
+        expect(logger.notCalled);
       });
 
       it('should play a segment if an object with startTime and endTime values is given', function(done) {

--- a/test/unit/api-view-spec.js
+++ b/test/unit/api-view-spec.js
@@ -3,15 +3,19 @@ import Peaks from '../../src/main';
 describe('WaveformView', function() {
   var p;
   var waveformLayerDraw;
+  var logger;
 
   beforeEach(function(done) {
+    logger = sinon.spy();
+
     var options = {
       containers: {
         overview: document.getElementById('overview-container'),
         zoomview: document.getElementById('zoomview-container')
       },
       mediaElement: document.getElementById('media'),
-      dataUri: 'base/test_data/sample.json'
+      dataUri: 'base/test_data/sample.json',
+      logger: logger
     };
 
     Peaks.init(options, function(err, instance) {
@@ -158,6 +162,58 @@ describe('WaveformView', function() {
           view.showAxisLabels(false);
 
           expect(axisLayerDraw.callCount).to.equal(1);
+        });
+      });
+    });
+  });
+
+  describe('setZoom', function() {
+    describe('zoomview', function() {
+      context('with scale option', function() {
+        context('with target scale greater than the original waveform data', function() {
+          it('should set the new zoom level', function() {
+            var view = p.views.getView('zoomview');
+
+            view.setZoom({ scale: 512 });
+
+            expect(view._scale).to.equal(512);
+            expect(logger.notCalled);
+          });
+        });
+
+        context('with target scale lower than the original waveform data', function() {
+          it('should log an error and not change the zoom level', function() {
+            var view = p.views.getView('zoomview');
+
+            view.setZoom({ scale: 128 });
+
+            expect(view._scale).to.equal(256);
+            expect(logger.calledOnce);
+          });
+        });
+      });
+
+      context('with seconds option', function() {
+        context('with target scale greater than the original waveform data', function() {
+          it('should set the new zoom level', function() {
+            var view = p.views.getView('zoomview');
+
+            view.setZoom({ seconds: 10.0 });
+
+            expect(view._scale).to.equal(441);
+            expect(logger.notCalled);
+          });
+        });
+
+        context('with target scale lower than the original waveform data', function() {
+          it('should log an error and not change the zoom level', function() {
+            var view = p.views.getView('zoomview');
+
+            view.setZoom({ seconds: 1.0 });
+
+            expect(view._scale).to.equal(256);
+            expect(logger.calledOnce);
+          });
         });
       });
     });


### PR DESCRIPTION
It seems that without `logger` defined in the `options` object, an error is thrown:

```sh
Uncaught TypeError: this._peaks.logger is not a function
    at WaveformZoomView.setZoom (peaks.js:14546)
    at zoomable-waveform.html:160
    at peaks.js:16876
    at peaks.js:16162
    at Worker.listener (peaks.js:16125)
```

Adding a `logger` definition makes the example work again.

Before submitting a pull request, please read our [contributor guidelines](https://github.com/bbc/peaks.js/blob/master/CONTRIBUTING.md).

Pull requests that don't follow the guidelines risk not being accepted.
