### PR TITLE
Fix a TOC jump link

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ To add the Peaks.js UMD bundle to your web page, add a `<script>` tag:
 
 The UMD bundle is available at [unpkg](https://unpkg.com/peaks.js) and [cdnjs](https://cdnjs.com/libraries/peaks.js).
 
-### ES module bundle
+### Install with npm
 
 We recommend that you use an ES module bundler.
 


### PR DESCRIPTION
Rename "ES module bundle" to "Install to npm" to make the TOC jump link work. 

I decided to rename the header of the documentation chapter, since a further explaining text uses "ES module bundler" anyway.
