### PR TITLE
Added functions to disable seek and drag/scroll interactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ You can read more about the project and see a demo [here](https://waveform.proto
     - [view.setZoom()](#viewsetzoomoptions)
     - [view.setStartTime()](#viewsetstarttimetime)
     - [view.setWheelMode()](#viewsetwheelmodemode)
+    - [view.enableDragScroll()](#viewenabledragscrollenable)
+    - [view.enableSeek()](#viewenableseekenable)
   - [Zoom API](#zoom-api)
     - [instance.zoom.zoomIn()](#instancezoomzoomin)
     - [instance.zoom.zoomOut()](#instancezoomzoomout)
@@ -1079,6 +1081,29 @@ Note that this method is not available on the overview waveform.
 ```js
 const view = instance.views.getView('zoomview');
 view.setWheelMode('scroll');
+```
+
+### `view.enableDragScroll(enable)`
+
+Enables or disables drag scrolling in the zoomable waveform view.
+
+Note that this method is not available on the overview waveform.
+
+```javascript
+const zoomview = peaksInstance.views.getView('zoomview');
+zoomview.enableDragScroll(false); // or true to re-enable
+```
+
+### `view.enableSeek(enable)`
+
+Enables or disables seeking the playback position by clicking in the waveform view.
+
+```js
+const overview = peaksInstance.views.getView('zoomview');
+const zoomview = peaksInstance.views.getView('zoomview');
+
+overview.enableSeek(false); // or true to re-enable
+zoomview.enableSeek(false);
 ```
 
 ## Zoom API

--- a/demo/index.html
+++ b/demo/index.html
@@ -157,6 +157,14 @@
           <button data-action="toggle-overview">Show/hide overview waveform</button>
           <button data-action="destroy">Destroy</button>
         </div>
+        <div>
+          <input type="checkbox" id="enable-drag-scroll" checked>
+          <label for="enable-drag-scroll">Enable drag scroll (zoomview only)</label>
+        </div>
+        <div>
+          <input type="checkbox" id="enable-seek" checked>
+          <label for="enable-seek">Enable click to seek</label>
+        </div>
       </div>
     </div>
 
@@ -426,6 +434,19 @@
           document.getElementById('playhead-time').addEventListener('change', function(event) {
             var view = peaksInstance.views.getView('zoomview');
             view.showPlayheadTime(event.target.checked);
+          });
+
+          document.getElementById('enable-drag-scroll').addEventListener('change', function(event) {
+            var zoomview = peaksInstance.views.getView('zoomview');
+            zoomview.enableDragScroll(event.target.checked);
+          });
+
+          document.getElementById('enable-seek').addEventListener('change', function(event) {
+            var overview = peaksInstance.views.getView('overview');
+            var zoomview = peaksInstance.views.getView('zoomview');
+
+            zoomview.enableSeek(event.target.checked);
+            overview.enableSeek(event.target.checked);
           });
 
           document.querySelector('body').addEventListener('click', function(event) {

--- a/peaks.js.d.ts
+++ b/peaks.js.d.ts
@@ -351,6 +351,7 @@ declare module 'peaks.js' {
     setTimeLabelPrecision: (precision: number) => void;
     showAxisLabels: (show: boolean) => void;
     enableMarkerEditing: (enable: boolean) => void;
+    enableSeek: (enable: boolean) => void;
     fitToContainer: () => void;
   }
 
@@ -363,6 +364,7 @@ declare module 'peaks.js' {
     setStartTime: (time: number) => void;
     setWheelMode: (mode: 'scroll' | 'none') => void;
     setZoom: (options: XOR<{ scale: number | 'auto' }, { seconds: number | 'auto' }>) => void;
+    enableDragScroll: (enable: boolean) => void;
   }
 
   interface PeaksInstance {


### PR DESCRIPTION
See #421. This PR adds new functions to allow applications to disable seek and drag/scroll interactions.

To disable drag/scroll in the zoomable waveform view:

```javascript
const zoomview = peaksInstance.views.getView('zoomview');
zoomview.enableDragScroll(false); // or true to re-enable
```

To disable seek on click (actually on mouse-up):

```javascript
const overview = peaksInstance.views.getView('zoomview');
const zoomview = peaksInstance.views.getView('zoomview');

overview.enableSeek(false); // or true to re-enable
zoomview.enableSeek(false);
```

How is this, @rowild?