### PR TITLE
Changed event handlers to also expose MouseEvent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1450,8 +1450,9 @@ Peaks instances emit events to enable you to extend its behaviour according to y
 Registers a callback function to handle events emitted by a Peaks instance.
 
 ```js
-function dblClickHandler(time) {
-  console.log('dblclick', time);
+function dblClickHandler(event) {
+  console.log(event.time); // Time position where the user clicked
+  console.log(event.evt.ctrlKey); // Access MouseEvent attributes
 }
 
 instance.on('zoomview.dblclick', dblClickHandler);
@@ -1479,12 +1480,12 @@ The following sections describe the available events.
 
 #### Views
 
-| Event name          | Arguments     |
-| ------------------- | ------------- |
-| `overview.click`    | `Number time` |
-| `overview.dblclick` | `Number time` |
-| `zoomview.click`    | `Number time` |
-| `zoomview.dblclick` | `Number time` |
+| Event name          | Arguments                      |
+| ------------------- | ------------------------------ |
+| `overview.click`    | `WaveformViewClickEvent event` |
+| `overview.dblclick` | `WaveformViewClickEvent event` |
+| `zoomview.click`    | `WaveformViewClickEvent event` |
+| `zoomview.dblclick` | `WaveformViewClickEvent event` |
 
 #### Waveforms
 
@@ -1499,13 +1500,13 @@ The following sections describe the available events.
 | `segments.add`            | `Array<Segment> segments`             |
 | `segments.remove`         | `Array<Segment> segments`             |
 | `segments.remove_all`     | (none)                                |
-| `segments.dragstart`      | `Segment segment`, `Boolean inMarker` |
-| `segments.dragged`        | `Segment segment`, `Boolean inMarker` |
-| `segments.dragend`        | `Segment segment`, `Boolean inMarker` |
-| `segments.mouseenter`     | `Segment segment`                     |
-| `segments.mouseleave`     | `Segment segment`                     |
-| `segments.click`          | `Segment segment`                     |
-| `segments.dblclick`       | `Segment segment`                     |
+| `segments.dragstart`      | `SegmentDragEvent event`              |
+| `segments.dragged`        | `SegmentDragEvent event`              |
+| `segments.dragend`        | `SegmentDragEvent event`              |
+| `segments.mouseenter`     | `SegmentEvent event`                  |
+| `segments.mouseleave`     | `SegmentEvent event`                  |
+| `segments.click`          | `SegmentEvent event`                  |
+| `segments.dblclick`       | `SegmentEvent event`                  |
 
 #### Points
 
@@ -1514,13 +1515,13 @@ The following sections describe the available events.
 | `points.add`              | `Array<Point> points` |
 | `points.remove`           | `Array<Point> points` |
 | `points.remove_all`       | (none)                |
-| `points.dragstart`        | `Point point`         |
-| `points.dragmove`         | `Point point`         |
-| `points.dragend`          | `Point point`         |
-| `points.mouseenter`       | `Point point`         |
-| `points.mouseleave`       | `Point point`         |
-| `points.click`            | `Point point`         |
-| `points.dblclick`         | `Point point`         |
+| `points.dragstart`        | `PointEvent event`    |
+| `points.dragmove`         | `PointEvent event`    |
+| `points.dragend`          | `PointEvent event`    |
+| `points.mouseenter`       | `PointEvent event`    |
+| `points.mouseleave`       | `PointEvent event`    |
+| `points.click`            | `PointEvent event`    |
+| `points.dblclick`         | `PointEvent event`    |
 
 #### Cue Events
 
@@ -1537,6 +1538,11 @@ To enable cue events, call `Peaks.init()` with the `{ emitCueEvents: true }` opt
 Registers a callback function to handle a single one-time event emitted by a Peaks instance.
 
 ```js
+function dblClickHandler(event) {
+  console.log(event.time); // Time position where the user clicked
+  console.log(event.evt.ctrlKey); // Access MouseEvent attributes
+}
+
 instance.once('zoomview.dblclick', dblClickHandler);
 ```
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -550,38 +550,38 @@
             console.log('points.mouseleave:', point);
           });
 
-          peaksInstance.on('points.click', function(point) {
-            console.log('points.click:', point);
+          peaksInstance.on('points.click', function(event) {
+            console.log('points.click:', event);
           });
 
-          peaksInstance.on('points.dblclick', function(point) {
-            console.log('points.dblclick:', point);
+          peaksInstance.on('points.dblclick', function(event) {
+            console.log('points.dblclick:', event);
           });
 
-          peaksInstance.on('points.dragstart', function(point) {
-            console.log('points.dragstart:', point);
+          peaksInstance.on('points.dragstart', function(event) {
+            console.log('points.dragstart:', event);
           });
 
-          peaksInstance.on('points.dragmove', function(point) {
-            console.log('points.dragmove:', point);
+          peaksInstance.on('points.dragmove', function(event) {
+            console.log('points.dragmove:', event);
           });
 
-          peaksInstance.on('points.dragend', function(point) {
-            console.log('points.dragend:', point);
+          peaksInstance.on('points.dragend', function(event) {
+            console.log('points.dragend:', event);
           });
 
           // Segments mouse events
 
-          peaksInstance.on('segments.dragstart', function(segment, startMarker) {
-            console.log('segments.dragstart:', segment, startMarker);
+          peaksInstance.on('segments.dragstart', function(event) {
+            console.log('segments.dragstart:', event);
           });
 
-          peaksInstance.on('segments.dragend', function(segment, startMarker) {
-            console.log('segments.dragend:', segment, startMarker);
+          peaksInstance.on('segments.dragend', function(event) {
+            console.log('segments.dragend:', event);
           });
 
-          peaksInstance.on('segments.dragged', function(segment, startMarker) {
-            console.log('segments.dragged:', segment, startMarker);
+          peaksInstance.on('segments.dragged', function(event) {
+            console.log('segments.dragged:', event);
           });
 
           peaksInstance.on('segments.mouseenter', function(segment) {
@@ -592,20 +592,20 @@
             console.log('segments.mouseleave:', segment);
           });
 
-          peaksInstance.on('segments.click', function(segment) {
-            console.log('segments.click:', segment);
+          peaksInstance.on('segments.click', function(event) {
+            console.log('segments.click:', event);
           });
 
-          peaksInstance.on('segments.dblclick', function(segment) {
-            console.log('segments.dblclick:', segment);
+          peaksInstance.on('segments.dblclick', function(event) {
+            console.log('segments.dblclick:', event);
           });
 
-          peaksInstance.on('zoomview.click', function(time) {
-            console.log('zoomview.click:', time);
+          peaksInstance.on('zoomview.click', function(event) {
+            console.log('zoomview.click:', event);
           });
 
-          peaksInstance.on('zoomview.dblclick', function(time) {
-            console.log('zoomview.dblclick:', time);
+          peaksInstance.on('zoomview.dblclick', function(event) {
+            console.log('zoomview.dblclick:', event);
           });
 
           peaksInstance.on('overview.click', function(time) {

--- a/demo/webaudio.html
+++ b/demo/webaudio.html
@@ -313,36 +313,6 @@
               peaksInstance.segments.removeById(id);
             }
           });
-
-          // Points mouse events
-
-          peaksInstance.on('points.mouseenter', function(point) {
-            console.log('points.mouseenter:', point);
-          });
-
-          peaksInstance.on('points.mouseleave', function(point) {
-            console.log('points.mouseleave:', point);
-          });
-
-          peaksInstance.on('points.click', function(point) {
-            console.log('points.click:', point);
-          });
-
-          peaksInstance.on('points.dblclick', function(point) {
-            console.log('points.dblclick:', point);
-          });
-
-          peaksInstance.on('points.dragstart', function(point) {
-            console.log('points.dragstart:', point);
-          });
-
-          peaksInstance.on('points.dragmove', function(point) {
-            console.log('points.dragmove:', point);
-          });
-
-          peaksInstance.on('points.dragend', function(point) {
-            console.log('points.dragend:', point);
-          });
         });
       })(peaks);
     </script>

--- a/peaks.js.d.ts
+++ b/peaks.js.d.ts
@@ -285,31 +285,56 @@ declare module 'peaks.js' {
 
   type SetSourceCallback = (error: Error) => void;
 
+  interface WaveformViewClickEvent {
+    time: number;
+    evt: MouseEvent;
+  }
+
+  interface PointEvent {
+    point: Point;
+    evt: MouseEvent;
+  }
+
+  interface SegmentEvent {
+    segment: Segment;
+    evt: MouseEvent;
+  }
+
+  interface SegmentDragEvent {
+    segment: Segment;
+    startMarker: boolean;
+    evt: MouseEvent;
+  }
+
   interface InstanceEvents {
     'peaks.ready': () => void;
     'points.add': (points: Point[]) => void;
-    'points.dblclick': (point: Point) => void;
-    'points.dragend': (point: Point) => void;
-    'points.dragmove': (point: Point) => void;
-    'points.dragstart': (point: Point) => void;
-    'points.mouseenter': (point: Point) => void;
-    'points.mouseleave': (point: Point) => void;
+    'points.click': (event: PointEvent) => void;
+    'points.dblclick': (event: PointEvent) => void;
+    'points.dragend': (event: PointEvent) => void;
+    'points.dragmove': (event: PointEvent) => void;
+    'points.dragstart': (event: PointEvent) => void;
+    'points.mouseenter': (event: PointEvent) => void;
+    'points.mouseleave': (event: PointEvent) => void;
     'points.remove_all': () => void;
     'points.remove': (points: Point[]) => void;
     'points.enter': (point: Point) => void;
     'segments.add': (segments: Segment[]) => void;
-    'segments.dragstart': (segment: Segment, startMarker: boolean) => void;
-    'segments.dragged': (segment: Segment, startMarker: boolean) => void;
-    'segments.dragend': (segment: Segment, startMarker: boolean) => void;
+    'segments.dragstart': (event: SegmentDragEvent) => void;
+    'segments.dragged': (event: SegmentDragEvent) => void;
+    'segments.dragend': (event: SegmentDragEvent) => void;
     'segments.remove_all': () => void;
     'segments.remove': (segments: Segment[]) => void;
-    'segments.mouseenter': (segment: Segment) => void;
-    'segments.mouseleave': (segment: Segment) => void;
-    'segments.click': (segment: Segment) => void;
+    'segments.mouseenter': (event: SegmentEvent) => void;
+    'segments.mouseleave': (event: SegmentEvent) => void;
+    'segments.click': (event: SegmentEvent) => void;
+    'segments.dblclick': (event: SegmentEvent) => void;
     'segments.enter': (segment: Segment) => void;
     'segments.exit': (segment: Segment) => void;
-    'overview.dblclick': (time: number) => void;
-    'zoomview.dblclick': (time: number) => void;
+    'overview.click': (event: WaveformViewClickEvent) => void;
+    'zoomview.click': (event: WaveformViewClickEvent) => void;
+    'overview.dblclick': (event: WaveformViewClickEvent) => void;
+    'zoomview.dblclick': (event: WaveformViewClickEvent) => void;
     'zoom.update': (currentZoomLevel: number, previousZoomLevel: number) => void;
   }
 

--- a/src/point-marker.js
+++ b/src/point-marker.js
@@ -61,16 +61,16 @@ function PointMarker(options) {
 PointMarker.prototype._bindDefaultEventHandlers = function() {
   var self = this;
 
-  self._group.on('dragstart', function() {
-    self._onDragStart(self._point);
+  self._group.on('dragstart', function(event) {
+    self._onDragStart(event, self._point);
   });
 
-  self._group.on('dragmove', function() {
-    self._onDragMove(self._point);
+  self._group.on('dragmove', function(event) {
+    self._onDragMove(event, self._point);
   });
 
-  self._group.on('dragend', function() {
-    self._onDragEnd(self._point);
+  self._group.on('dragend', function(event) {
+    self._onDragEnd(event, self._point);
   });
 
   self._group.on('click', function() {
@@ -81,12 +81,18 @@ PointMarker.prototype._bindDefaultEventHandlers = function() {
     self._onDblClick(self._point);
   });
 
-  self._group.on('mouseenter', function() {
-    self._onMouseEnter(self._point);
+  self._group.on('mouseenter', function(event) {
+    self._onMouseEnter({
+      point: self._point,
+      evt: event.evt
+    });
   });
 
-  self._group.on('mouseleave', function() {
-    self._onMouseLeave(self._point);
+  self._group.on('mouseleave', function(event) {
+    self._onMouseLeave({
+      point: self._point,
+      evt: event.evt
+    });
   });
 };
 

--- a/src/points-layer.js
+++ b/src/points-layer.js
@@ -183,7 +183,7 @@ PointsLayer.prototype._addPointMarker = function(point) {
  * @param {Point} point
  */
 
-PointsLayer.prototype._onPointHandleDragMove = function(point) {
+PointsLayer.prototype._onPointHandleDragMove = function(event, point) {
   var pointMarker = this._pointMarkers[point.id];
 
   var markerX = pointMarker.getX();
@@ -196,7 +196,10 @@ PointsLayer.prototype._onPointHandleDragMove = function(point) {
     pointMarker.timeUpdated(point.time);
   }
 
-  this._peaks.emit('points.dragmove', point);
+  this._peaks.emit('points.dragmove', {
+    point: point,
+    evt: event.evt
+  });
 };
 
 /**
@@ -231,16 +234,22 @@ PointsLayer.prototype._onPointHandleDblClick = function(point) {
  * @param {Point} point
  */
 
-PointsLayer.prototype._onPointHandleDragStart = function(point) {
-  this._peaks.emit('points.dragstart', point);
+PointsLayer.prototype._onPointHandleDragStart = function(event, point) {
+  this._peaks.emit('points.dragstart', {
+    point: point,
+    evt: event.evt
+  });
 };
 
 /**
  * @param {Point} point
  */
 
-PointsLayer.prototype._onPointHandleDragEnd = function(point) {
-  this._peaks.emit('points.dragend', point);
+PointsLayer.prototype._onPointHandleDragEnd = function(event, point) {
+  this._peaks.emit('points.dragend', {
+    point: point,
+    evt: event.evt
+  });
 };
 
 /**

--- a/src/segment-marker.js
+++ b/src/segment-marker.js
@@ -60,16 +60,16 @@ SegmentMarker.prototype._bindDefaultEventHandlers = function() {
   var self = this;
 
   if (self._draggable) {
-    self._group.on('dragmove', function() {
-      self._onDrag(self);
+    self._group.on('dragmove', function(event) {
+      self._onDrag(event, self);
     });
 
-    self._group.on('dragstart', function() {
-      self._onDragStart(self);
+    self._group.on('dragstart', function(event) {
+      self._onDragStart(event, self);
     });
 
-    self._group.on('dragend', function() {
-      self._onDragEnd(self);
+    self._group.on('dragend', function(event) {
+      self._onDragEnd(event, self);
     });
   }
 };

--- a/src/segment-shape.js
+++ b/src/segment-shape.js
@@ -182,36 +182,48 @@ SegmentShape.prototype._createMarkers = function() {
   }
 };
 
-SegmentShape.prototype._onMouseEnter = function() {
+SegmentShape.prototype._onMouseEnter = function(event) {
   if (this._label) {
     this._label.moveToTop();
     this._label.show();
   }
 
-  this._peaks.emit('segments.mouseenter', this._segment);
+  this._peaks.emit('segments.mouseenter', {
+    segment: this._segment,
+    evt: event.evt
+  });
 };
 
-SegmentShape.prototype._onMouseLeave = function() {
+SegmentShape.prototype._onMouseLeave = function(event) {
   if (this._label) {
     this._label.hide();
   }
 
-  this._peaks.emit('segments.mouseleave', this._segment);
+  this._peaks.emit('segments.mouseleave', {
+    segment: this._segment,
+    evt: event.evt
+  });
 };
 
-SegmentShape.prototype._onClick = function() {
-  this._peaks.emit('segments.click', this._segment);
+SegmentShape.prototype._onClick = function(event) {
+  this._peaks.emit('segments.click', {
+    segment: this._segment,
+    evt: event.evt
+  });
 };
 
-SegmentShape.prototype._onDblClick = function() {
-  this._peaks.emit('segments.dblclick', this._segment);
+SegmentShape.prototype._onDblClick = function(event) {
+  this._peaks.emit('segments.dblclick', {
+    segment: this._segment,
+    evt: event.evt
+  });
 };
 
 /**
  * @param {SegmentMarker} segmentMarker
  */
 
-SegmentShape.prototype._onSegmentHandleDrag = function(segmentMarker) {
+SegmentShape.prototype._onSegmentHandleDrag = function(event, segmentMarker) {
   var width = this._view.getWidth();
 
   var startMarker = segmentMarker.isStartMarker();
@@ -236,27 +248,39 @@ SegmentShape.prototype._onSegmentHandleDrag = function(segmentMarker) {
     segmentMarker.timeUpdated(this._segment.endTime);
   }
 
-  this._peaks.emit('segments.dragged', this._segment, startMarker);
+  this._peaks.emit('segments.dragged', {
+    segment: this._segment,
+    startMarker: startMarker,
+    evt: event.evt
+  });
 };
 
 /**
  * @param {SegmentMarker} segmentMarker
  */
 
-SegmentShape.prototype._onSegmentHandleDragStart = function(segmentMarker) {
+SegmentShape.prototype._onSegmentHandleDragStart = function(event, segmentMarker) {
   var startMarker = segmentMarker.isStartMarker();
 
-  this._peaks.emit('segments.dragstart', this._segment, startMarker);
+  this._peaks.emit('segments.dragstart', {
+    segment: this._segment,
+    startMarker: startMarker,
+    evt: event.evt
+  });
 };
 
 /**
  * @param {SegmentMarker} segmentMarker
  */
 
-SegmentShape.prototype._onSegmentHandleDragEnd = function(segmentMarker) {
+SegmentShape.prototype._onSegmentHandleDragEnd = function(event, segmentMarker) {
   var startMarker = segmentMarker.isStartMarker();
 
-  this._peaks.emit('segments.dragend', this._segment, startMarker);
+  this._peaks.emit('segments.dragend', {
+    segment: this._segment,
+    startMarker: startMarker,
+    evt: event.evt
+  });
 };
 
 SegmentShape.prototype.fitToView = function() {

--- a/src/segments-layer.js
+++ b/src/segments-layer.js
@@ -113,8 +113,8 @@ SegmentsLayer.prototype._onSegmentsRemoveAll = function() {
   this._segmentShapes = {};
 };
 
-SegmentsLayer.prototype._onSegmentsDragged = function(segment) {
-  this._updateSegment(segment);
+SegmentsLayer.prototype._onSegmentsDragged = function(event) {
+  this._updateSegment(event.segment);
 };
 
 /**

--- a/src/waveform-overview.js
+++ b/src/waveform-overview.js
@@ -191,7 +191,10 @@ WaveformOverview.prototype._clickHandler = function(event, eventName) {
   var pixelIndex = event.evt.layerX;
   var time = this.pixelsToTime(pixelIndex);
 
-  this._peaks.emit(eventName, time);
+  this._peaks.emit(eventName, {
+    time: time,
+    evt: event.evt
+  });
 };
 
 WaveformOverview.prototype.getName = function() {

--- a/src/waveform-zoomview.js
+++ b/src/waveform-zoomview.js
@@ -208,7 +208,10 @@ WaveformZoomView.prototype._clickHandler = function(event, eventName) {
   var mousePosX = event.evt.layerX;
   var time = this.pixelOffsetToTime(mousePosX);
 
-  this._peaks.emit(eventName, time);
+  this._peaks.emit(eventName, {
+    time: time,
+    evt: event.evt
+  });
 };
 
 WaveformZoomView.prototype.setWheelMode = function(mode) {


### PR DESCRIPTION
See issue #414. This changes a number of event handlers to also expose the MouseEvent, so that applications can, for example, check the keyboard state. This is a breaking API change and so users will need to update their code, as shown below.

### Waveform events

- `overview.click`, `overview.dblclick`, 
- `zoomview.click`, `zoomview.dblclick`

```js
// Before
peaks.on('zoomview.click', function(time) {
  console.log(time);
});

// After
peaks.on('zoomview.click', function(event) {
  console.log(event.time);
  console.log(event.evt.ctrlKey);
  console.log(event.evt.shiftKey);
});
```

### Point events

- `points.dragstart`, `points.dragmove`, `points.dragend`
- `points.mouseenter`, `points.mouseleave`
- `points.click`, `points.dblclick`

```js
// Before
peaks.on('point.click', function(time) {
  console.log(time);
});

// After
peaks.on('point.click', function(event) {
  console.log(event.point);
  console.log(event.evt.ctrlKey);
  console.log(event.evt.shiftKey);
});
```

### Segment events

- `segments.dragstart`, `segments.dragged`, `segments.dragend`

```js
// Before
peaks.on('segments.dragged', function(segment, startMarker) {
  console.log(segment);
  console.log(startMarker);
});

// After
peaks.on('segments.dragged', function(event) {
  console.log(event.segment);
  console.log(event.startMarker);
  console.log(event.evt.ctrlKey);
  console.log(event.evt.shiftKey);
});
```

- `segments.mouseenter`, `segments.mouseleave`
- `segments.click`, `segments.dblclick`

```js
// Before
peaks.on('segments.click', function(time) {
  console.log(time);
});

// After
peaks.on('segments.click', function(event) {
  console.log(event.segment);
  console.log(event.evt.ctrlKey);
  console.log(event.evt.shiftKey);
});
```
