### PR TITLE
label waveformCache prop as optional

### DIFF
--- a/peaks.js.d.ts
+++ b/peaks.js.d.ts
@@ -203,7 +203,7 @@ declare module 'peaks.js' {
     /** Array of zoom levels in samples per pixel (big >> small) */
     zoomLevels?: number[];
     /** Enable or disable the waveform cache */
-    waveformCache: boolean;
+    waveformCache?: boolean;
     /** Bind keyboard controls */
     keyboard?: boolean;
     /** Keyboard nudge increment in seconds (left arrow/right arrow) */


### PR DESCRIPTION
This PR fixes a little typo in the typescript definition: The waveform cache is currently not labelled as optional in typescript, even though it is intended to be optional.
