### PR TITLE
Improve horizontal scrolling on trackpads

### DIFF
--- a/src/waveform-zoomview.js
+++ b/src/waveform-zoomview.js
@@ -294,7 +294,7 @@ WaveformZoomView.prototype._onWheel = function(event) {
   else {
     // Ignore the event if it looks like the user is scrolling vertically
     // down the page
-    if (wheelEvent.deltaY !== 0) {
+    if (Math.abs(wheelEvent.deltaX) < Math.abs(wheelEvent.deltaY)) {
       return;
     }
 


### PR DESCRIPTION
Apparently I didn't review https://github.com/bbc/peaks.js/issues/454 carefully enough - I've come to realise it makes scrolling pretty awful on my Macbook Pro in Safari, where 50% of the time a horizontal swipe would try to navigate the page backwards & forwards rather than scrolling the waveform.