### PR TITLE
feat(): highlight region styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,6 +464,16 @@ var options = {
     // that shows what the zoomable view shows
     highlightColor: 'grey',
 
+
+    // Stroke color for the zoomed region
+    highlightStrokeColor:   'transparent',
+
+    // Opacity for the zoomed region
+    highlightOpacity:       0.3,
+
+    // Corner Radius for the zoomed region
+    highlightCornerRadius:  2,
+
     // The default number of pixels from the top and bottom of the canvas
     // that the overviewHighlight takes up
     highlightOffset: 11,

--- a/demo/index.html
+++ b/demo/index.html
@@ -281,8 +281,7 @@
             playheadClickTolerance: 3
           },
           overview: {
-            container: document.getElementById('overview-container'),
-            // highlightColor: 'rgba(0, 0, 0, 0.1)',
+            container: document.getElementById('overview-container')
           },
           mediaElement: document.getElementById('audio'),
           dataUri: {
@@ -293,7 +292,7 @@
           pointMarkerColor: '#006eb0',
           showPlayheadTime: true,
           waveformCache: true,
-          zoomLevels: [512, 1024, 2048, 4096],
+          zoomLevels: [512, 1024, 2048, 4096]
         };
 
         Peaks.init(options, function(err, peaksInstance) {

--- a/demo/index.html
+++ b/demo/index.html
@@ -281,7 +281,8 @@
             playheadClickTolerance: 3
           },
           overview: {
-            container: document.getElementById('overview-container')
+            container: document.getElementById('overview-container'),
+            // highlightColor: 'rgba(0, 0, 0, 0.1)',
           },
           mediaElement: document.getElementById('audio'),
           dataUri: {
@@ -292,7 +293,7 @@
           pointMarkerColor: '#006eb0',
           showPlayheadTime: true,
           waveformCache: true,
-          zoomLevels: [512, 1024, 2048, 4096]
+          zoomLevels: [512, 1024, 2048, 4096],
         };
 
         Peaks.init(options, function(err, peaksInstance) {

--- a/src/highlight-layer.js
+++ b/src/highlight-layer.js
@@ -23,7 +23,7 @@ import { clamp } from  './utils';
  * @param {String} color
  */
 
-function HighlightLayer(view, offset, color) {
+function HighlightLayer(view, offset, color, strokeColor, opacity, cornerRadius) {
   this._view          = view;
   this._offset        = offset;
   this._color         = color;
@@ -31,6 +31,9 @@ function HighlightLayer(view, offset, color) {
   this._highlightRect = null;
   this._startTime     = null;
   this._endTime       = null;
+  this._strokeColor   = strokeColor;
+  this._opacity       = opacity;
+  this._cornerRadius  = cornerRadius;
 }
 
 HighlightLayer.prototype.addToStage = function(stage) {
@@ -77,12 +80,12 @@ HighlightLayer.prototype._createHighlightRect = function(startTime, endTime) {
     x:            startOffset,
     y:            0,
     width:        endOffset - startOffset,
-    stroke:       this._color,
+    stroke:       this._strokeColor,
     strokeWidth:  1,
     height:       0,
     fill:         this._color,
-    opacity:      0.3,
-    cornerRadius: 2
+    opacity:      this._opacity,
+    cornerRadius: this._cornerRadius,
   });
 
   this.fitToView();

--- a/src/highlight-layer.js
+++ b/src/highlight-layer.js
@@ -23,17 +23,17 @@ import { clamp } from  './utils';
  * @param {String} color
  */
 
-function HighlightLayer(view, offset, color, strokeColor, opacity, cornerRadius) {
+function HighlightLayer(view, viewOptions) {
   this._view          = view;
-  this._offset        = offset;
-  this._color         = color;
+  this._offset        = viewOptions.highlightOffset;
+  this._color         = viewOptions.highlightColor;
   this._layer         = new Konva.Layer({ listening: false });
   this._highlightRect = null;
   this._startTime     = null;
   this._endTime       = null;
-  this._strokeColor   = strokeColor;
-  this._opacity       = opacity;
-  this._cornerRadius  = cornerRadius;
+  this._strokeColor   = viewOptions.highlightStrokeColor;
+  this._opacity       = viewOptions.highlightOpacity;
+  this._cornerRadius  = viewOptions.highlightCornerRadius;
 }
 
 HighlightLayer.prototype.addToStage = function(stage) {
@@ -85,7 +85,7 @@ HighlightLayer.prototype._createHighlightRect = function(startTime, endTime) {
     height:       0,
     fill:         this._color,
     opacity:      this._opacity,
-    cornerRadius: this._cornerRadius,
+    cornerRadius: this._cornerRadius
   });
 
   this.fitToView();

--- a/src/main.js
+++ b/src/main.js
@@ -93,7 +93,7 @@ var defaultZoomviewOptions = {
 var defaultOverviewOptions = {
   // showPlayheadTime:    false,
   waveformColor:          'rgba(0, 0, 0, 0.2)',
-  highlightColor:         '#aaa',
+  highlightColor:         '#aaaaaa',
   highlightStrokeColor:   'transparent',
   highlightOpacity:       0.3,
   highlightOffset:        11,

--- a/src/main.js
+++ b/src/main.js
@@ -92,9 +92,12 @@ var defaultZoomviewOptions = {
 
 var defaultOverviewOptions = {
   // showPlayheadTime:    false,
-  waveformColor:       'rgba(0, 0, 0, 0.2)',
-  highlightColor:      '#aaaaaa',
-  highlightOffset:     11
+  waveformColor:          'rgba(0, 0, 0, 0.2)',
+  highlightColor:         '#aaa',
+  highlightStrokeColor:   'transparent',
+  highlightOpacity:       0.3,
+  highlightOffset:        11,
+  highlightCornerRadius:  2
 };
 
 function getOverviewOptions(opts) {
@@ -136,6 +139,9 @@ function getOverviewOptions(opts) {
     'fontSize',
     'fontStyle',
     'highlightColor',
+    'highlightStrokeColor',
+    'highlightOpacity',
+    'highlightCornerRadius',
     'highlightOffset'
   ];
 

--- a/src/waveform-overview.js
+++ b/src/waveform-overview.js
@@ -103,11 +103,7 @@ function WaveformOverview(waveformData, container, peaks) {
 
   self._highlightLayer = new HighlightLayer(
     self,
-    self._viewOptions.highlightOffset,
-    self._viewOptions.highlightColor,
-    self._viewOptions.highlightStrokeColor,
-    self._viewOptions.highlightOpacity,
-    self._viewOptions.highlightCornerRadius
+    self._viewOptions
   );
   self._highlightLayer.addToStage(self._stage);
 

--- a/src/waveform-overview.js
+++ b/src/waveform-overview.js
@@ -104,7 +104,10 @@ function WaveformOverview(waveformData, container, peaks) {
   self._highlightLayer = new HighlightLayer(
     self,
     self._viewOptions.highlightOffset,
-    self._viewOptions.highlightColor
+    self._viewOptions.highlightColor,
+    self._viewOptions.highlightStrokeColor,
+    self._viewOptions.highlightOpacity,
+    self._viewOptions.highlightCornerRadius
   );
   self._highlightLayer.addToStage(self._stage);
 


### PR DESCRIPTION
BBC Team,

First off, thanks for this incredible library. Secondly, I apologize for not discussing this prior to the PR, but I hope this will be received well.

I have a strong desire to further visually customize Peaks.js. In this PR, the highlight region. Here is an example of my particular design usecase. Might be worth exploring a way to extend Konva options for every Konva object but honestly, this looks beautiful to me and I'm very happy with the ability to set these options.

<img width="740" alt="Screen Shot 2022-10-12 at 8 10 04 AM" src="https://user-images.githubusercontent.com/1041792/195380998-5dc3b302-19c0-4837-97dd-75f79a54314c.png">
