### PR TITLE
Relax konva version range

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "node": ">= 8.11.2"
       },
       "peerDependencies": {
-        "konva": ">= 8.3.14 < 9",
+        "konva": ">= 8.3.14 < 10",
         "waveform-data": ">= 4.3.0 < 5"
       }
     },

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "eventemitter3": "~5.0.1"
   },
   "peerDependencies": {
-    "konva": ">= 8.3.14 < 9",
+    "konva": ">= 8.3.14 < 10",
     "waveform-data": ">= 4.3.0 < 5"
   }
 }


### PR DESCRIPTION
Konva 9.0 / 9.1 have been working fine for us with peaks. How about relaxing the version range?