### PR TITLE
playheadPadding should be optional in ViewOptions

### DIFF
--- a/peaks.js.d.ts
+++ b/peaks.js.d.ts
@@ -95,7 +95,7 @@ declare module 'peaks.js' {
     showPlayheadTime?: boolean;
     playheadTextColor?: string;
     playheadBackgroundColor?: string;
-    playheadPadding: number;
+    playheadPadding?: number;
     formatPlayheadTime?: FormatTimeFunction;
     timeLabelPrecision?: number;
     showAxisLabels?: boolean;


### PR DESCRIPTION
This is defaulted to 2 in defaultViewOptions, so as far as I can tell should be an optional property here?