### PR TITLE
Added filterPoints option to WaveformView

### DIFF
--- a/peaks.js.d.ts
+++ b/peaks.js.d.ts
@@ -81,7 +81,7 @@ declare module 'peaks.js' {
 
   interface GlobalSegmentDisplayOptions extends SegmentDisplayOptions {
     waveformColor?: WaveformColor;
-    overlayColor?:  string;
+    overlayColor?: string;
   }
 
   type FormatTimeFunction = (time: number) => string;
@@ -108,6 +108,7 @@ declare module 'peaks.js' {
     enablePoints?: boolean;
     enableSegments?: boolean;
     segmentOptions?: SegmentDisplayOptions;
+    filterPoints?: ((p: Point) => boolean) | null;
   }
 
   interface ZoomViewOptions extends ViewOptions {

--- a/src/main.js
+++ b/src/main.js
@@ -82,7 +82,8 @@ const defaultViewOptions = {
   fontStyle:               'normal',
   timeLabelPrecision:      2,
   enablePoints:            true,
-  enableSegments:          true
+  enableSegments:          true,
+  filterPoints:            null
 };
 
 const defaultZoomviewOptions = {
@@ -166,7 +167,8 @@ function getOverviewOptions(opts) {
     'highlightOffset',
     'enablePoints',
     'enableSegments',
-    'enableEditing'
+    'enableEditing',
+    'filterPoints'
   ];
 
   optNames.forEach(function(optName) {
@@ -225,7 +227,8 @@ function getZoomviewOptions(opts) {
     'autoScrollOffset',
     'enablePoints',
     'enableSegments',
-    'enableEditing'
+    'enableEditing',
+    'filterPoints'
   ];
 
   optNames.forEach(function(optName) {

--- a/src/waveform-points.js
+++ b/src/waveform-points.js
@@ -180,6 +180,9 @@ WaveformPoints.prototype.add = function(/* pointOrPoints */) {
 };
 
 WaveformPoints.prototype.updatePointId = function(point, newPointId) {
+  if (point.id === newPointId) {
+    return;
+  }
   if (this._pointsById[point.id]) {
     if (this._pointsById[newPointId]) {
       throw new Error('point.update(): duplicate id');

--- a/src/waveform-view.js
+++ b/src/waveform-view.js
@@ -70,7 +70,8 @@ function WaveformView(waveformData, container, peaks, viewOptions) {
   }
 
   if (self._viewOptions.enablePoints) {
-    self._pointsLayer = new PointsLayer(peaks, self, self._viewOptions.enableEditing);
+    self._pointsLayer = new PointsLayer(peaks, self, self._viewOptions.enableEditing,
+      self._viewOptions.filterPoints);
     self._pointsLayer.addToStage(self._stage);
   }
 


### PR DESCRIPTION
This allows the user to provide a function that controls whether a particular point is displayed on the Waveform. Main use case: there are a lot of points on the overview, and only a small part of them are actually important to see there.

What might be missing here is something to emit `points.update` in case the user changes something in their filter function and visible points need to be recomputed.

You don't need to merge this btw, I'm just adding stuff I need here and there, so if you don't want things upstream no problem at all.