### PR TITLE
Relax konva version range

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "node": ">= 20.0.0"
       },
       "peerDependencies": {
-        "konva": ">= 8.3.14 < 10",
+        "konva": ">= 8.3.14 < 11",
         "waveform-data": ">= 4.5.1 < 5"
       }
     },
@@ -7068,9 +7068,9 @@
       }
     },
     "node_modules/konva": {
-      "version": "9.3.20",
-      "resolved": "https://registry.npmjs.org/konva/-/konva-9.3.20.tgz",
-      "integrity": "sha512-7XPD/YtgfzC8b1c7z0hhY5TF1IO/pBYNa29zMTA2PeBaqI0n5YplUeo4JRuRcljeAF8lWtW65jePZZF7064c8w==",
+      "version": "10.0.8",
+      "resolved": "https://registry.npmjs.org/konva/-/konva-10.0.8.tgz",
+      "integrity": "sha512-kQqErBIj2mR/srYDheRD2hq5v0gkwqoJZvbPz3DhCcyRNJfMEnd/AzLhWz2f567BB9vtL2p2EqKwI6n+MyM9Hw==",
       "funding": [
         {
           "type": "patreon",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "eventemitter3": "~5.0.1"
   },
   "peerDependencies": {
-    "konva": ">= 8.3.14 < 10",
+    "konva": ">= 8.3.14 < 11",
     "waveform-data": ">= 4.5.1 < 5"
   }
 }


### PR DESCRIPTION
Konva 10 seems to work fine with peaks, how about relaxing the version range in peerDependencies?